### PR TITLE
Fix booking prisoner step

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ ruby '2.3.0'
 
 gem 'rails', '~> 4.2.3'
 
+gem 'excon'
 gem 'govuk_frontend_toolkit', '2.0.1'
 gem 'high_voltage'
 gem 'kramdown'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,6 +82,7 @@ GEM
     docile (1.1.5)
     equalizer (0.0.11)
     erubis (2.7.0)
+    excon (0.45.4)
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
@@ -321,6 +322,7 @@ DEPENDENCIES
   byebug
   capybara
   database_cleaner
+  excon
   ffaker
   fuubar
   govuk_frontend_toolkit (= 2.0.1)

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -9,10 +9,7 @@ class Prison
   attribute :postcode, String
   attribute :email_address, String
   attribute :phone_no, String
-
-  def finder_slug
-    'TODO' # Not yet reported by API
-  end
+  attribute :prison_finder_url, String
 
   def self.find_by_id(id)
     result = Rails.configuration.api.get("/prisons/#{id}")

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -1,8 +1,23 @@
 class Prison
   include NonPersistedModel
 
+  MAX_VISITORS = 6
+
   attribute :id, String
   attribute :name, String
+  attribute :address, String
+  attribute :postcode, String
+  attribute :email_address, String
+  attribute :phone_no, String
+
+  def finder_slug
+    'TODO' # Not yet reported by API
+  end
+
+  def self.find_by_id(id)
+    result = Rails.configuration.api.get("/prisons/#{id}")
+    Prison.new(result['prison'])
+  end
 
   def self.all
     result = Rails.configuration.api.get('/prisons')

--- a/app/models/prison.rb
+++ b/app/models/prison.rb
@@ -1,0 +1,11 @@
+class Prison
+  include NonPersistedModel
+
+  attribute :id, String
+  attribute :name, String
+
+  def self.all
+    result = Rails.configuration.api.get('/prisons')
+    result['prisons'].map { |params| Prison.new(params) }
+  end
+end

--- a/app/models/prisoner_step.rb
+++ b/app/models/prisoner_step.rb
@@ -16,6 +16,6 @@ class PrisonerStep
   delegate :name, to: :prison, prefix: true
 
   def prison
-    Prison.find_by(id: prison_id)
+    prison_id ? Prison.find_by(id: prison_id) : nil
   end
 end

--- a/app/models/prisoner_step.rb
+++ b/app/models/prisoner_step.rb
@@ -16,6 +16,6 @@ class PrisonerStep
   delegate :name, to: :prison, prefix: true
 
   def prison
-    prison_id ? Prison.find_by(id: prison_id) : nil
+    prison_id ? Prison.find_by_id(prison_id) : nil
   end
 end

--- a/app/services/link_directory.rb
+++ b/app/services/link_directory.rb
@@ -3,6 +3,7 @@ require 'uri_template'
 class LinkDirectory
   GOOGLE_MAPS = 'http://google.com/maps?q={query}'
   RATE_SERVICE = 'http://www.gov.uk/done/prison-visits'
+  PRISON_FINDER = 'http://www.justice.gov.uk/contacts/prison-finder'
 
   def google_maps(query)
     URITemplate.new(GOOGLE_MAPS).expand(query: query)
@@ -10,5 +11,9 @@ class LinkDirectory
 
   def rate_service
     RATE_SERVICE
+  end
+
+  def prison_finder
+    PRISON_FINDER
   end
 end

--- a/app/services/link_directory.rb
+++ b/app/services/link_directory.rb
@@ -4,14 +4,6 @@ class LinkDirectory
   GOOGLE_MAPS = 'http://google.com/maps?q={query}'
   RATE_SERVICE = 'http://www.gov.uk/done/prison-visits'
 
-  def initialize(prison_finder:)
-    @prison_finder_template = URITemplate.new(prison_finder)
-  end
-
-  def prison_finder(prison = nil)
-    @prison_finder_template.expand(prison: prison ? prison.finder_slug : nil)
-  end
-
   def google_maps(query)
     URITemplate.new(GOOGLE_MAPS).expand(query: query)
   end

--- a/app/services/prison_visits_api.rb
+++ b/app/services/prison_visits_api.rb
@@ -1,0 +1,22 @@
+require 'excon'
+
+class PrisonVisitsAPI
+  def initialize(host)
+    @host = host
+    @connection = Excon.new(host, persistent: true)
+  end
+
+  def get(route, params = {})
+    options = {
+      path: "/api/#{route}.json",
+      expects: [200],
+      headers: {
+        'Accept' => 'application/json',
+        'Accept-Language' => 'en'
+      },
+      query: params
+    }
+    response = @connection.get(options)
+    JSON.parse(response.body)
+  end
+end

--- a/app/services/steps_processor.rb
+++ b/app/services/steps_processor.rb
@@ -55,6 +55,6 @@ private
 
   def prison_attributes
     prison_id = params.fetch(:prisoner_step, {}).fetch(:prison_id, nil)
-    prison_id ? { prison: Prison.find_by(id: prison_id) } : {}
+    prison_id ? { prison: Prison.find_by_id(prison_id) } : {}
   end
 end

--- a/app/views/booking_requests/_contact_prison.html.erb
+++ b/app/views/booking_requests/_contact_prison.html.erb
@@ -1,2 +1,1 @@
-<p><%= t('.help_html',
-         url: link_directory.prison_finder(prison)) %></p>
+<p><%= t('.help_html', url: prison ? prison.prison_finder_url : nil) %></p>

--- a/app/views/booking_requests/prisoner_step.html.erb
+++ b/app/views/booking_requests/prisoner_step.html.erb
@@ -36,7 +36,7 @@
         <%= single_field(f, :number, :text_field) %>
 
         <%= single_field(f, :prison_id, :select,
-              Prison.enabled.map { |p| [p.name, p.id] },
+              Prison.all.map { |p| [p.name, p.id] },
               { prompt: t('.prison_id_prompt') },
               { class: 'js-autocomplete' }) %>
 

--- a/config/application.rb
+++ b/config/application.rb
@@ -49,5 +49,7 @@ module PrisonVisits
     if ENV['ASSET_HOST']
       config.asset_host = ENV['ASSET_HOST']
     end
+
+    config.api_host = ENV.fetch('PRISON_VISITS_API', 'http://localhost:3001/')
   end
 end

--- a/config/initializers/link_directory.rb
+++ b/config/initializers/link_directory.rb
@@ -1,3 +1,1 @@
-Rails.configuration.link_directory = LinkDirectory.new(
-  prison_finder: 'http://www.justice.gov.uk/contacts/prison-finder{/prison}'
-)
+Rails.configuration.link_directory = LinkDirectory.new

--- a/config/initializers/pvb_api.rb
+++ b/config/initializers/pvb_api.rb
@@ -1,0 +1,3 @@
+Rails.configuration.api = PrisonVisitsAPI.new(
+  Rails.configuration.api_host
+)

--- a/spec/services/link_directory_spec.rb
+++ b/spec/services/link_directory_spec.rb
@@ -1,20 +1,4 @@
 require 'rails_helper'
 
 RSpec.describe LinkDirectory do
-  subject {
-    described_class.new(prison_finder: 'http://pf.example.com/find{/prison}')
-  }
-
-  describe 'prison_finder' do
-    it 'returns the base URL without a prison' do
-      expect(subject.prison_finder).
-        to eq('http://pf.example.com/find')
-    end
-
-    it 'appends the prison finder slug to the base URL' do
-      prison = instance_double('Prison', finder_slug: 'luna')
-      expect(subject.prison_finder(prison)).
-        to eq('http://pf.example.com/find/luna')
-    end
-  end
 end


### PR DESCRIPTION
Fixes the first 2 steps in the booking process, and integrates with the prison/index and prison/show APIs using a simple client.

This is still at proof of concept stage, and I have not written or tried running any of the tests post the great split.

@threedaymonk I think finder_slug needs adding to the API for prison finder. Or perhaps the API could return a prison finder url?