### PR TITLE
Update Excon to latest version

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,7 +83,7 @@ GEM
     docile (1.1.5)
     equalizer (0.0.11)
     erubis (2.7.0)
-    excon (0.48.0)
+    excon (0.49.0)
     execjs (2.6.0)
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)


### PR DESCRIPTION
Bump to the latest version so that pvb-public and pvb2 use the same version