### PR TITLE
Make rubocop more lenient

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -75,7 +75,7 @@ Metrics/LineLength:
 
 # Don't worry about long methods in specs.
 Metrics/MethodLength:
-  Max: 10
+  Max: 12
   Exclude:
     - 'spec/**/*'
     - 'app/helpers/form_elements_helper.rb'

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -123,4 +123,9 @@ ClassAndModuleChildren:
 Rails/Delegate:
   Enabled: false
 
+# Enforcing timezone in specs is unecessary
+Rails/TimeZone:
+  Exclude:
+    - 'spec/**/*'
+
 require: rubocop-rspec

--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -37,7 +37,6 @@ private
 
   # rubocop:disable Metrics/CyclomaticComplexity
   # rubocop:disable Metrics/PerceivedComplexity
-  # rubocop:disable Metrics/MethodLength
   def compute_error
     return :unparseable unless parsed
     return :domain_dot if domain_dot_error?
@@ -53,7 +52,6 @@ private
   end
   # rubocop:enable Metrics/CyclomaticComplexity
   # rubocop:enable Metrics/PerceivedComplexity
-  # rubocop:enable Metrics/MethodLength
 
   def override_sendgrid?
     @override_sendgrid || !Rails.configuration.enable_sendgrid_validations

--- a/app/services/steps_processor.rb
+++ b/app/services/steps_processor.rb
@@ -6,7 +6,7 @@ class StepsProcessor
     @locale = locale
 
     # Compute now to avoid keeping @params
-    @steps_submitted = STEP_NAMES.select { |s| params.has_key?(s) }
+    @steps_submitted = STEP_NAMES.select { |s| params.key?(s) }
     @review_step = STEP_NAMES.find { |s| s.to_s == params[:review_step].to_s }
   end
 

--- a/lib/maybe_date.rb
+++ b/lib/maybe_date.rb
@@ -6,7 +6,6 @@ class MaybeDate < Virtus::Attribute
   # This coercion is probably not as comprehensive as
   # Virtus::Attribute::Date, but it is understandable and sufficient for
   # our needs
-  # rubocop:disable Metrics/MethodLength
   def coerce(value)
     return nil if value.nil?
     return value if value.is_a?(Date)
@@ -22,5 +21,4 @@ class MaybeDate < Virtus::Attribute
       end
     end
   end
-  # rubocop:enable Metrics/MethodLength
 end


### PR DESCRIPTION
@alan, as discussed. This removes your spec changes to add timezone, which I decided to exclude globally in specs.