### PR TITLE
Friendly date validation error

### DIFF
--- a/app/models/prisoner_step.rb
+++ b/app/models/prisoner_step.rb
@@ -30,7 +30,11 @@ class PrisonerStep
 
 private
 
+  # rubocop:disable Metrics/AbcSize
   def validate_prisoner
+    # If date_of_birth of number are invalid, there's no need to call the API
+    return if errors[:date_of_birth].any? || errors[:number].any?
+
     result = PrisonVisits::Api.instance.validate_prisoner(
       number: number,
       date_of_birth: date_of_birth
@@ -44,4 +48,5 @@ private
       errors.add :date_of_birth, I18n.t(error_nomatch, scope: I18N_SCOPE)
     end
   end
+  # rubocop:enable Metrics/AbcSize
 end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -11,6 +11,8 @@ en:
           attributes:
             number:
               invalid: is invalid
+            date_of_birth:
+              inclusion: is not a valid date
           api:
             prisoner_does_not_exist: does not match any prisoner
         visitors_step:
@@ -23,6 +25,11 @@ en:
                 %{age} on this visit
               too_many_visitors:
                 You can book a maximum of %{max} visitors
+        visitors_step/visitor:
+          attributes:
+            date_of_birth:
+              inclusion: is not a valid date
+
   activerecord:
     errors:
       models:

--- a/spec/models/prisoner_step_spec.rb
+++ b/spec/models/prisoner_step_spec.rb
@@ -53,4 +53,10 @@ RSpec.describe PrisonerStep do
     expect(subject.errors.messages).to have_key(:number)
     expect(subject.errors.messages).to have_key(:date_of_birth)
   end
+
+  it 'does not call the PVB API if the date is invalid' do
+    params[:date_of_birth][:month] = '13'
+    expect(pvb_api).not_to receive(:validate_prisoner)
+    expect(subject.valid?).to be false
+  end
 end


### PR DESCRIPTION
As well as adding a nicer message, this fixes an integration bug where the prisoner validation API would be called even if the date or prison number were invalid.