### PR TITLE
Monitor api calls

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -13,20 +13,12 @@ private
 
   # :nocov:
 
-  def append_to_log(params)
-    @custom_log_items ||= {}
-    @custom_log_items.merge!(params)
-  end
-
   # Looks rather strange, but this is the suggested mechanism to add extra data
   # into the event passed to lograge's custom options. The method is part of
   # Rails' instrumentation code, and is run after each request.
   def append_info_to_payload(payload)
     super
-
-    append_to_log(request_id: RequestStore.store[:request_id])
-
-    payload[:custom_log_items] = @custom_log_items
+    payload[:custom_log_items] = Instrumentation.custom_log_items
   end
 
   def http_referrer
@@ -52,6 +44,7 @@ private
   end
 
   def store_request_id
+    Instrumentation.append_to_log(request_id: request.uuid)
     RequestStore.store[:request_id] = request.uuid
   end
 end

--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -5,7 +5,7 @@ class BookingRequestsController < ApplicationController
     processor = StepsProcessor.new(params, I18n.locale)
     @steps = processor.steps
     @step_name = processor.step_name
-    append_to_log booking_step_rendered: processor.step_name
+    Instrumentation.append_to_log booking_step_rendered: processor.step_name
 
     respond_to do |format|
       format.html { render processor.step_name }
@@ -17,8 +17,8 @@ class BookingRequestsController < ApplicationController
     @visit = processor.execute!
     @steps = processor.steps
     @step_name = processor.step_name
-    append_to_log booking_step_rendered: processor.step_name
-    append_to_log visit_id: @visit.id if @visit
+    Instrumentation.append_to_log booking_step_rendered: processor.step_name
+    Instrumentation.append_to_log visit_id: @visit.id if @visit
 
     respond_to do |format|
       format.html { render processor.step_name }

--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -43,10 +43,11 @@ private
     return :malformed unless well_formed_address?
     return :no_mx_record unless mx_records?
     unless override_sendgrid?
-      Metrics.log('Validating email address via Sendgrid API') do
-        return :spam_reported if SendgridApi.spam_reported?(parsed.address)
-        return :bounced if SendgridApi.bounced?(parsed.address)
-      end
+      Instrumentation.
+        time_and_log('Validating email address via Sendgrid API') do
+          return :spam_reported if SendgridApi.spam_reported?(parsed.address)
+          return :bounced if SendgridApi.bounced?(parsed.address)
+        end
     end
     :valid
   end
@@ -77,7 +78,7 @@ private
   end
 
   def mx_records?
-    Metrics.log('Validating email address MX record') do
+    Instrumentation.time_and_log('Validating email address MX record') do
       Rails.configuration.mx_checker.records?(domain)
     end
   end

--- a/app/services/instrumentation.rb
+++ b/app/services/instrumentation.rb
@@ -1,17 +1,36 @@
-class Instrumentation
+module Instrumentation
   class << self
-    def log(message, category = nil)
+    def append_to_log(payload)
+      RequestStore.store[:custom_log_items] ||= {}
+      RequestStore.store[:custom_log_items].merge!(payload)
+    end
+
+    def custom_log_items
+      RequestStore.store[:custom_log_items] || {}
+    end
+
+    def time_and_log(message, category = nil)
       fail 'Block required' unless block_given?
 
+      result, time_in_ms = time_action { yield }
+
+      Rails.logger.info "#{message} – %.2fms" % [time_in_ms]
+
+      if category
+        total_time = time_in_ms + custom_log_items[category].to_i
+        append_to_log(category => total_time)
+      end
+      result
+    end
+
+  private
+
+    def time_action
       started_at = Time.now.utc
       result = yield
       finished_at = Time.now.utc
       time_in_ms = (finished_at - started_at) * 1000
-
-      Rails.logger.info "#{message} – %.2fms" % [time_in_ms]
-
-      RequestStore.store[category] = time_in_ms if category
-      result
+      [result, time_in_ms]
     end
   end
 end

--- a/app/services/instrumentation.rb
+++ b/app/services/instrumentation.rb
@@ -1,6 +1,6 @@
 class Instrumentation
   class << self
-    def log(category, message)
+    def log(message, category = nil)
       fail 'Block required' unless block_given?
 
       started_at = Time.now.utc
@@ -10,7 +10,7 @@ class Instrumentation
 
       Rails.logger.info "#{message} – %.2fms" % [time_in_ms]
 
-      RequestStore.store[category] = time_in_ms
+      RequestStore.store[category] = time_in_ms if category
       result
     end
   end

--- a/app/services/instrumentation.rb
+++ b/app/services/instrumentation.rb
@@ -1,4 +1,4 @@
-class Metrics
+class Instrumentation
   class << self
     def log(category, message)
       fail 'Block required' unless block_given?
@@ -10,8 +10,7 @@ class Metrics
 
       Rails.logger.info "#{message} – %.2fms" % [time_in_ms]
 
-      ## Add Request::Store totals by category, writes to log at the end of the request.
-
+      RequestStore.store[category] = time_in_ms
       result
     end
   end

--- a/app/services/metrics.rb
+++ b/app/services/metrics.rb
@@ -1,6 +1,6 @@
 class Metrics
   class << self
-    def log(message)
+    def log(category, message)
       fail 'Block required' unless block_given?
 
       started_at = Time.now.utc
@@ -9,6 +9,8 @@ class Metrics
       time_in_ms = (finished_at - started_at) * 1000
 
       Rails.logger.info "#{message} – %.2fms" % [time_in_ms]
+
+      ## Add Request::Store totals by category, writes to log at the end of the request.
 
       result
     end

--- a/spec/services/instrumentation_spec.rb
+++ b/spec/services/instrumentation_spec.rb
@@ -1,43 +1,101 @@
 require 'rails_helper'
 
 RSpec.describe Instrumentation do
-  describe '.log' do
+  let!(:start_time) { Time.zone.now.utc }
+  let!(:end_time) { start_time + 5.seconds }
+  let!(:utc) { double('utc') }
+
+  before do
+    # Keep the timings DRY and consistent across specs.
+    allow(utc).to receive(:utc).and_return(start_time, end_time)
+    # `at_least` because Rails.logger uses it as well.
+    allow(Time).to receive(:now).at_least(:twice).and_return(utc)
+
+    # Because the specs get run in a single thread
+    RequestStore.clear!
+  end
+
+  describe '.append_to_log' do
+    it 'adds' do
+      expect(described_class.append_to_log(fu: 'bar')).
+        to eq(fu: 'bar')
+    end
+
+    it 'changes' do
+      described_class.append_to_log(fu: 'bang')
+      expect(described_class.append_to_log(fu: 'bar')).
+        to eq(fu: 'bar')
+    end
+
+    it 'appends' do
+      described_class.append_to_log(fu: 'bar')
+      expect(described_class.append_to_log(sna: 'fu')).
+        to eq(fu: 'bar', sna: 'fu')
+    end
+  end
+
+  describe '.custom_log_items' do
+    it 'lists all' do
+      described_class.append_to_log(sna: 'fu')
+      described_class.append_to_log(fu: 'bar')
+      described_class.append_to_log(tar: 'fu')
+      expect(described_class.custom_log_items).
+        to eq(fu: 'bar',
+              sna: 'fu',
+              tar: 'fu')
+    end
+  end
+
+  describe '.time_and_log' do
     it 'requires a block' do
-      expect { described_class.log(:arg, 'arg') }.to raise_error(/Block required/)
+      expect { described_class.time_and_log(:arg, 'arg') }.to raise_error(/Block required/)
     end
 
     it 'yields the block' do
-      expect { |b| described_class.log(:arg, 'arg', &b) }.to yield_with_no_args
+      expect { |b| described_class.time_and_log(:arg, 'arg', &b) }.to yield_with_no_args
     end
 
     it 'logs the message' do
       expect(Rails.logger).to receive(:info).with(/arg/)
-      described_class.log(:arg, 'arg') { true }
+      described_class.time_and_log(:arg, 'arg') { true }
     end
 
     it 'returns the result of the block' do
-      expect(described_class.log(:arg, 'arg') { 1 + 1 }).to eq(2)
+      expect(described_class.time_and_log(:arg, 'arg') { 1 + 1 }).to eq(2)
     end
 
     context 'timing' do
-      let!(:start_time) { Time.zone.now.utc }
+      it 'calculates the run time of the block' do
         expect(Rails.logger).to receive(:info).with(/5000.00ms/)
-        described_class.log(:arg, 'arg') { true }
+        described_class.time_and_log(:arg, 'arg') do
+          true
+        end
       end
-      let!(:end_time) { start_time + 5.seconds }
+    end
 
     context 'categories' do
-      let!(:utc) { double('utc') }
-
-      before do
-        allow(utc).to receive(:utc).and_return(start_time, end_time)
-        allow(Time).to receive(:now).twice.and_return(utc)
-        described_class.log('A prisoner API call', :prisoner_api) { true }
+      it 'appends/adds to the correct category' do
+        described_class.time_and_log('fu', :bar) do
+          true
+        end
+        expect(described_class.custom_log_items[:bar]).to eq(5000)
       end
 
       it 'does not require a category' do
-        expect(RequestStore).not_to receive(:store)
-        described_class.log('A prisoner API call') { true }
+        expect(described_class).not_to receive(:append_to_log)
+        described_class.time_and_log('A prisoner API call') do
+          true
+        end
+      end
+
+      context 'timing' do
+        it 'adds time to an existing category' do
+          described_class.append_to_log(long_time: 1000)
+          described_class.time_and_log('fubar', :long_time) do
+            true
+          end
+          expect(described_class.custom_log_items[:long_time]).to eq(6000)
+        end
       end
     end
   end

--- a/spec/services/instrumentation_spec.rb
+++ b/spec/services/instrumentation_spec.rb
@@ -21,17 +21,23 @@ RSpec.describe Instrumentation do
 
     context 'timing' do
       let!(:start_time) { Time.zone.now.utc }
+        expect(Rails.logger).to receive(:info).with(/5000.00ms/)
+        described_class.log(:arg, 'arg') { true }
+      end
       let!(:end_time) { start_time + 5.seconds }
+
+    context 'categories' do
       let!(:utc) { double('utc') }
 
       before do
         allow(utc).to receive(:utc).and_return(start_time, end_time)
         allow(Time).to receive(:now).twice.and_return(utc)
+        described_class.log('A prisoner API call', :prisoner_api) { true }
       end
 
-      it 'calculates the run time of the block' do
-        expect(Rails.logger).to receive(:info).with(/5000.00ms/)
-        described_class.log(:arg, 'arg') { true }
+      it 'does not require a category' do
+        expect(RequestStore).not_to receive(:store)
+        described_class.log('A prisoner API call') { true }
       end
     end
   end

--- a/spec/services/instrumentation_spec.rb
+++ b/spec/services/instrumentation_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Metrics do
+RSpec.describe Instrumentation do
   describe '.log' do
     it 'requires a block' do
       expect { described_class.log(:arg, 'arg') }.to raise_error(/Block required/)

--- a/spec/services/metrics_spec.rb
+++ b/spec/services/metrics_spec.rb
@@ -1,0 +1,38 @@
+require 'rails_helper'
+
+RSpec.describe Metrics do
+  describe '.log' do
+    it 'requires a block' do
+      expect { described_class.log(:arg, 'arg') }.to raise_error(/Block required/)
+    end
+
+    it 'yields the block' do
+      expect { |b| described_class.log(:arg, 'arg', &b) }.to yield_with_no_args
+    end
+
+    it 'logs the message' do
+      expect(Rails.logger).to receive(:info).with(/arg/)
+      described_class.log(:arg, 'arg') { true }
+    end
+
+    it 'returns the result of the block' do
+      expect(described_class.log(:arg, 'arg') { 1 + 1 }).to eq(2)
+    end
+
+    context 'timing' do
+      let!(:start_time) { Time.zone.now.utc }
+      let!(:end_time) { start_time + 5.seconds }
+      let!(:utc) { double('utc') }
+
+      before do
+        allow(utc).to receive(:utc).and_return(start_time, end_time)
+        allow(Time).to receive(:now).twice.and_return(utc)
+      end
+
+      it 'calculates the run time of the block' do
+        expect(Rails.logger).to receive(:info).with(/5000.00ms/)
+        described_class.log(:arg, 'arg') { true }
+      end
+    end
+  end
+end


### PR DESCRIPTION
This PR moves the append_to_log method out of the application controller, tries to make the name of the metrics class somewhat more explicit, and add timing tracking to the log instrument. 