### PR TITLE
Validate that the lead visitor is over 18

### DIFF
--- a/app/models/booking_constraints.rb
+++ b/app/models/booking_constraints.rb
@@ -25,7 +25,7 @@ class BookingConstraints
 
   class VisitorConstraints
     MAX_ADULTS = 3
-    MIN_ADULTS = 1
+    LEAD_VISITOR_MIN_AGE = 18
 
     def initialize(prison)
       @adult_age = prison.adult_age
@@ -35,14 +35,17 @@ class BookingConstraints
     attr_reader :adult_age, :max_visitors
 
     def validate_visitor_ages_on(target, field, ages)
+      # The person requesting the visit (the lead visitor) must be over 18, and
+      # corresponds to the first visitor entered.
+      # Note that this is not related to the 'adult' age which varies by prison.
+      if ages.empty? || ages.first < LEAD_VISITOR_MIN_AGE
+        target.errors.add(field, :lead_visitor_age, min: LEAD_VISITOR_MIN_AGE)
+      end
+
       adults, _children = ages.partition { |a| adult?(a) }.map(&:length)
       if adults > MAX_ADULTS
         target.errors.add field, :too_many_adults,
           max: MAX_ADULTS,
-          age: adult_age
-      elsif adults < MIN_ADULTS
-        target.errors.add field, :too_few_adults,
-          min: MIN_ADULTS,
           age: adult_age
       end
     end

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -18,8 +18,8 @@ en:
         visitors_step:
           attributes:
             general:
-              too_few_adults:
-                There must be at least one adult visitor
+              lead_visitor_age:
+                The person requesting the visit must be over the age of %{min}
               too_many_adults:
                 You can book a maximum of %{max} visitors over the age of
                 %{age} on this visit


### PR DESCRIPTION
This implements the same validation added to PVB2 in https://github.com/ministryofjustice/prison-visits-2/pull/298, with a few improvements

* It corrects the behaviour if there are no visitors (it should be invalid)
* Rewrote the specs to be higher level, and thereby much simpler