### PR TITLE
Improve Rails errors

### DIFF
--- a/app/controllers/errors_controller.rb
+++ b/app/controllers/errors_controller.rb
@@ -12,12 +12,16 @@ class ErrorsController < ApplicationController
   before_action :set_html_format, only: :show
 
   def show
-    status_code = params.fetch(:status_code).to_i
+    Instrumentation.append_to_log(original_fullpath: request.original_fullpath)
+
+    status_code = env['PATH_INFO'][1..-1]
 
     # Explicity protect against rendering an unexpected template (although such
     # a situation should not be possible with a correct routes definition)
-    template_to_render = SUPPORTED_ERRORS.fetch(status_code)
-    render template_to_render, status: status_code, format: :html
+    template_to_render = SUPPORTED_ERRORS.fetch(status_code.to_i)
+    render template_to_render,
+      status: status_code,
+      format: :html
   end
 
   def test

--- a/app/middleware/error_handler.rb
+++ b/app/middleware/error_handler.rb
@@ -1,0 +1,22 @@
+# Our Rails exception_app is a Rails controller action. As such it tries to
+# parse the params before processing the action, to do this it relies on Rack,
+# which raises an error if the query string is invalid.
+#
+# To stop the error bubbling out into an unstyled 500 page we need to modify the
+# 'env' to clear the query string before calling the action.
+class ErrorHandler
+  def self.call(env)
+    unless valid_query_string?(env['QUERY_STRING'])
+      env['QUERY_STRING'] = ''
+    end
+
+    ErrorsController.action(:show).call(env)
+  end
+
+  def self.valid_query_string?(query_string)
+    Rack::Utils.parse_nested_query(query_string)
+    true
+  rescue
+    false
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -75,7 +75,11 @@
   </li>
   <% alternative_locales.each do |locale| %>
     <li>
-      <%= link_to(t('language', locale: locale), locale: locale) %>
+      <% if controller_name == 'errors' %>
+        <%= link_to(t('language', locale: locale), "/#{response.status}?locale=#{locale}")%>
+      <% else %>
+        <%= link_to(t('language', locale: locale), locale: locale) %>
+      <% end %>
     </li>
   <% end %>
 <% end %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -22,8 +22,12 @@ module PrisonVisits
 
     config.time_zone = 'London'
 
+    # The last 3 errors can be removed with Rails 5. See Rails PR #19632
     config.action_dispatch.rescue_responses.merge!(
-      'StateMachines::InvalidTransition' => :unprocessable_entity
+      'StateMachines::InvalidTransition' => :unprocessable_entity,
+      'ActionController::ParameterMissing' => :bad_request,
+      'Rack::Utils::ParameterTypeError' => :bad_request,
+      'Rack::Utils::InvalidParameterError' => :bad_request
     )
 
     config.ga_id = ENV['GA_TRACKING_ID']

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,7 +44,7 @@ module PrisonVisits
           )
       )
 
-    config.exceptions_app = routes
+    config.exceptions_app = ->(env) { ErrorHandler.call(env) }
 
     if ENV['ASSET_HOST']
       config.asset_host = ENV['ASSET_HOST']

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -41,19 +41,19 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "8c390dff3f40970d84fbba866e35c1f62e8ea4629c767e5df706bf873bc39f40",
+      "fingerprint": "2b3a1157063993c962dd2b41351e4e24a0f2be5a63f818f13ee2d8a5b964f3f2",
       "message": "Render path contains parameter value",
       "file": "app/controllers/errors_controller.rb",
-      "line": 20,
+      "line": 22,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => { 404 => :\"404\", 406 => :\"404\", 500 => :\"500\", 503 => :\"503\" }.fetch(params.fetch(:status_code).to_i), { :status => params.fetch(:status_code).to_i, :format => :html })",
+      "code": "render(action => { 404 => :\"404\", 406 => :\"404\", 500 => :\"500\", 503 => :\"503\" }.fetch((params[:status_code] or env[\"PATH_INFO\"][(1..-1)]).to_i), { :status => ((params[:status_code] or env[\"PATH_INFO\"][(1..-1)])), :format => :html })",
       "render_path": null,
       "location": {
         "type": "method",
         "class": "ErrorsController",
         "method": "show"
       },
-      "user_input": "params.fetch(:status_code)",
+      "user_input": "params[:status_code]",
       "confidence": "Weak",
       "note": ""
     },

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,10 +1,11 @@
 Rails.application.routes.draw do
   get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
 
-  %w[ 404 406 500 503 ].each do |code|
-    match code, to: 'errors#show', status_code: code, via: %i[ get post ]
-  end
   match 'exception', to: 'errors#test', via: %i[ get post ]
+
+  if Rails.env.test?
+    match 'error_handling', to: 'errors#show', via: :get
+  end
 
   # Old pvb1 path to start a booking
   get '/prisoner', to: redirect('/en/request')

--- a/spec/controllers/errors_controller_spec.rb
+++ b/spec/controllers/errors_controller_spec.rb
@@ -5,7 +5,10 @@ RSpec.describe ErrorsController do
 
   %w[ 404 406 500 503 ].each do |status_code|
     it "renders #{status_code} page with the given status" do
-      get :show, status_code: status_code
+      allow(controller).
+        to receive(:env).and_return('PATH_INFO' => "/#{status_code}")
+
+      get :show
       expect(response.status).to eq(status_code.to_i)
     end
   end

--- a/spec/middlewares/error_handler_spec.rb
+++ b/spec/middlewares/error_handler_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe ErrorHandler do
+  describe '.call' do
+    let(:env) do
+      {
+        'QUERY_STRING' => query_string,
+        'PATH_INFO' => '/500'
+      }
+    end
+
+    subject { described_class.call(env) }
+
+    let(:show_action) { double('Show action', call: true) }
+
+    before do
+      expect(ErrorsController).
+        to receive(:action).with(:show).and_return(show_action)
+    end
+
+    context 'with a valid query string' do
+      let!(:query_string) { 'a=b' }
+
+      it 'calls the error controller with the original query string' do
+        expect(show_action).to receive(:call).with(env)
+        subject
+      end
+    end
+
+    context 'with an invalid query string' do
+      let!(:query_string) { 'b=1&b[a]=2' }
+
+      it 'calls the error controller with a blank query string' do
+        new_env = env.dup
+        new_env['QUERY_STRING'] = ''
+
+        expect(show_action).to receive(:call).with(new_env)
+        subject
+      end
+    end
+  end
+end


### PR DESCRIPTION
Our exception app is an ActionController action (they are Rack apps), the
problem is that if an error happens inside that application it will be bubble
out of the error app resulting in a non-styled error page showed to the user and
the error not being reported to Sentry.

We've seen this happen with invalid query strings that involve invalid nested
attributes. To fix this we need to detect if the query string is invalid before
is processed by the exception app, otherwise the controller will try to parse
the query string before processing the main body of the action and raise an
error.

An alternative of doing this would be decoupling our error pages from Rails
controllers / views, and have a Rack app that has the same behaviour while not
having to use the query string.