### PR TITLE
Show lead visitor age validation error on field

### DIFF
--- a/app/models/booking_constraints.rb
+++ b/app/models/booking_constraints.rb
@@ -38,10 +38,6 @@ class BookingConstraints
       # The person requesting the visit (the lead visitor) must be over 18, and
       # corresponds to the first visitor entered.
       # Note that this is not related to the 'adult' age which varies by prison.
-      if ages.empty? || ages.first < LEAD_VISITOR_MIN_AGE
-        target.errors.add(field, :lead_visitor_age, min: LEAD_VISITOR_MIN_AGE)
-      end
-
       adults, _children = ages.partition { |a| adult?(a) }.map(&:length)
       if adults > MAX_ADULTS
         target.errors.add field, :too_many_adults,

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -10,6 +10,15 @@ class VisitorsStep
     attribute :first_name, String
     attribute :last_name, String
     attribute :date_of_birth, MaybeDate
+    attribute :lead, Boolean, default: false
+
+    validate :validate_lead_visitor_age, if: ->(v) { v.lead }
+
+    def validate_lead_visitor_age
+      if age < 18
+        errors.add(:date_of_birth, min: 18)
+      end
+    end
   end
 
   attribute :processor, StepsProcessor
@@ -48,6 +57,10 @@ class VisitorsStep
     pruned = ParameterPruner.new.prune(
       params.sort_by { |k, _| k.to_i }.map(&:last)
     )
+
+    if pruned.any?
+      pruned.first.merge!(lead: true)
+    end
 
     # We always want at least one visitor. Leaving the rest blank is fine, but
     # the first one must both exist and be valid.


### PR DESCRIPTION
Proof of concept for https://trello.com/c/N6GGQPRr/137-bug-copy-in-error-message-for-age-validation-says-see-highlighted-below-but-the-field-isn-t-highlighted

The lead visitor needs to validate its own age for the error to appear next to the relevant field.

It feels like the visitor step could do with a refactor, I don't like the implicit lead visitor based on being the first visitor on the array. Also, it feels like the lead visitor should include the email_address and phone_number fields and validate those.

It would make more sense if the visitor_step consisted of 1 lead visitor (with email and phone number) and and array of additional visitors and nothing else.