### PR TITLE
Send request_id to Sentry

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -46,5 +46,6 @@ private
   def store_request_id
     Instrumentation.append_to_log(request_id: request.uuid)
     RequestStore.store[:request_id] = request.uuid
+    Raven.extra_context(request_id: request.uuid)
   end
 end


### PR DESCRIPTION
Should make debugging errors easier. I've also double checked the Raven source
for that method and should be threadsafe.