### PR TITLE
Retry idempotent API requests (up to 3 attempts)

### DIFF
--- a/app/services/prison_visits/api.rb
+++ b/app/services/prison_visits/api.rb
@@ -32,8 +32,11 @@ module PrisonVisits
     def validate_prisoner(number:, date_of_birth:)
       result = @client.post(
         '/validations/prisoner',
-        number: number,
-        date_of_birth: date_of_birth
+        params: {
+          number: number,
+          date_of_birth: date_of_birth
+        },
+        idempotent: true
       )
       result.fetch('validation')
     end
@@ -43,16 +46,18 @@ module PrisonVisits
     )
       response = @client.get(
         '/slots',
-        prison_id: prison_id,
-        prisoner_number: prisoner_number,
-        prisoner_dob: prisoner_dob,
-        use_nomis_slots: use_nomis_slots
+        params: {
+          prison_id: prison_id,
+          prisoner_number: prisoner_number,
+          prisoner_dob: prisoner_dob,
+          use_nomis_slots: use_nomis_slots
+        }
       )
       response['slots'].map { |s| ConcreteSlot.parse(s) }
     end
 
     def request_visit(params)
-      response = @client.post('/visits', params)
+      response = @client.post('/visits', params: params)
       Visit.new(response.fetch('visit'))
     end
 
@@ -76,7 +81,7 @@ module PrisonVisits
         }
       }
 
-      @client.post('/feedback', params)
+      @client.post('/feedback', params: params)
       nil
     end
   end

--- a/spec/fixtures/vcr_cassettes/client_json_error_idempotent.yml
+++ b/spec/fixtures/vcr_cassettes/client_json_error_idempotent.yml
@@ -1,0 +1,120 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/prisons/missing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.49.0
+      Accept:
+      - application/json
+      Accept-Language:
+      - en
+      X-Request-Id:
+      - unique_id
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - unique_id
+      X-Runtime:
+      - '0.013603'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Not found"}'
+    http_version:
+  recorded_at: Fri, 13 May 2016 10:30:53 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/api/prisons/missing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.49.0
+      Accept:
+      - application/json
+      Accept-Language:
+      - en
+      X-Request-Id:
+      - unique_id
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - unique_id
+      X-Runtime:
+      - '0.012533'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Not found"}'
+    http_version:
+  recorded_at: Fri, 13 May 2016 10:30:53 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/api/prisons/missing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.49.0
+      Accept:
+      - application/json
+      Accept-Language:
+      - en
+      X-Request-Id:
+      - unique_id
+  response:
+    status:
+      code: 404
+      message: ''
+    headers:
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Xss-Protection:
+      - 1; mode=block
+      X-Content-Type-Options:
+      - nosniff
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - unique_id
+      X-Runtime:
+      - '0.011858'
+    body:
+      encoding: UTF-8
+      string: '{"message":"Not found"}'
+    http_version:
+  recorded_at: Fri, 13 May 2016 10:30:53 GMT
+recorded_with: VCR 3.0.1


### PR DESCRIPTION
By default GET & DELETE requests are marked as idempotent (and therefore retried), while POST requests are not (see http://tools.ietf.org/html/rfc7231#section-4.2.2). It's possible to override on a per-method basis if desired, and this is done for the prisoner validation API which is in fact safe.

* Changed the internal API between API & Client to allow for passing idempotent flag