### PR TITLE
Validate the selected slots is a bookable slot

### DIFF
--- a/app/models/booking_constraints.rb
+++ b/app/models/booking_constraints.rb
@@ -46,6 +46,10 @@ class BookingConstraints
       @slots.any? { |s| s.to_date == requested_date }
     end
 
+    def bookable_slot?(requested_slot)
+      @slots.include?(requested_slot)
+    end
+
     def last_bookable_date
       @slots.sort.last.to_date
     end

--- a/app/models/concrete_slot.rb
+++ b/app/models/concrete_slot.rb
@@ -48,8 +48,8 @@ ConcreteSlot = Struct.new(
     (end_at - begin_at).to_i
   end
 
-  # Arbitrarily define the sort order to correspond with the start time
+  # Sort by begin date and slot duration
   def <=>(other)
-    begin_at <=> other.begin_at
+    iso8601 <=> other.iso8601
   end
 end

--- a/app/models/slots_step.rb
+++ b/app/models/slots_step.rb
@@ -13,9 +13,13 @@ class SlotsStep
     allow_blank: true
   } do |record, attr, value|
     begin
-      ConcreteSlot.parse(value) # rescue ArgumentError false
+      slot = ConcreteSlot.parse(value) # rescue ArgumentError false
     rescue ArgumentError
       record.errors.add(attr, 'must start with upper case')
+    end
+
+    if slot && !record.slot_constraints.bookable_slot?(slot)
+      record.errors.add(attr, 'is not a bookable slot')
     end
   end
   # rubocop:enable Style/BracesAroundHashParameters

--- a/app/models/slots_step.rb
+++ b/app/models/slots_step.rb
@@ -15,7 +15,7 @@ class SlotsStep
     begin
       slot = ConcreteSlot.parse(value) # rescue ArgumentError false
     rescue ArgumentError
-      record.errors.add(attr, 'must start with upper case')
+      record.errors.add(attr, 'is not a parseable slot')
     end
 
     if slot && !record.slot_constraints.bookable_slot?(slot)

--- a/spec/models/concrete_slot_spec.rb
+++ b/spec/models/concrete_slot_spec.rb
@@ -66,11 +66,27 @@ RSpec.describe ConcreteSlot do
   end
 
   describe 'sorting (<=>)' do
-    it 'sorts slots according to their start time' do
+    it 'sorts slots according to their start time and slot length' do
       earlier_slot = described_class.new(2015, 10, 23, 14, 0, 18, 30)
       later_slot   = described_class.new(2015, 10, 23, 17, 0, 17, 30)
+      later_but_longer = described_class.new(2015, 10, 23, 17, 0, 18, 00)
 
       expect(earlier_slot).to be < later_slot
+      expect(later_slot).to be < later_but_longer
+    end
+
+    it 'slots with the same date and slot are equal' do
+      slot1 = described_class.new(2015, 10, 23, 14, 0, 18, 30)
+      slot2 = described_class.new(2015, 10, 23, 14, 0, 18, 30)
+
+      expect(slot1).to eq(slot2)
+    end
+
+    it 'slots of the same date but different slot are not equal' do
+      slot1 = described_class.new(2015, 10, 23, 14, 0, 18, 30)
+      slot2 = described_class.new(2015, 10, 23, 14, 0, 19, 30)
+
+      expect(slot1).to_not eq(slot2)
     end
   end
 end

--- a/spec/models/slots_step_spec.rb
+++ b/spec/models/slots_step_spec.rb
@@ -2,9 +2,20 @@ require 'rails_helper'
 
 RSpec.describe SlotsStep, type: :model do
   describe 'validation of options' do
-    subject { described_class.new }
+    subject(:instance) { described_class.new }
 
     let(:slot) { ConcreteSlot.new(2015, 1, 2, 9, 0, 10, 0) }
+
+    let(:prisoner_step) {
+      instance_double(PrisonerStep, first_name: 'John')
+    }
+
+    let(:processor) {
+      instance_double(StepsProcessor,
+        booking_constraints: booking_constraints,
+        prisoner_step: prisoner_step)
+    }
+
     let(:booking_constraints) {
       instance_double(
         BookingConstraints,
@@ -13,7 +24,11 @@ RSpec.describe SlotsStep, type: :model do
     }
 
     before do
-      allow(BookingConstraints).to receive(:new).and_return booking_constraints
+      allow(instance).
+        to receive(:processor).and_return(processor)
+
+      allow(processor).to receive(:booking_constraints).
+        and_return(booking_constraints)
     end
 
     it 'is valid if the option is a correctly formatted time range' do
@@ -34,6 +49,16 @@ RSpec.describe SlotsStep, type: :model do
       subject.option_0 = ''
       subject.validate
       expect(subject.errors).to have_key(:option_0)
+    end
+
+    it 'is invalid if the slots are not bookable slots' do
+      subject.option_0 = '2015-01-02T09:00/11:00'
+      subject.option_1 = '2015-01-02T09:00/12:00'
+      subject.option_2 = '2015-01-02T09:00/13:00'
+      subject.validate
+      expect(subject.errors).to have_key(:option_0)
+      expect(subject.errors).to have_key(:option_1)
+      expect(subject.errors).to have_key(:option_2)
     end
 
     it 'is valid if option_1 is empty' do

--- a/spec/services/steps_processor_spec.rb
+++ b/spec/services/steps_processor_spec.rb
@@ -203,6 +203,11 @@ RSpec.describe StepsProcessor do
       }
     }
 
+    before do
+      allow_any_instance_of(BookingConstraints::SlotConstraints).
+        to receive(:bookable_slot?).and_return(true)
+    end
+
     it 'chooses the confirmation template' do
       expect(subject.step_name).to eq(:confirmation_step)
     end
@@ -220,6 +225,17 @@ RSpec.describe StepsProcessor do
     it 'initialises the SlotsStep with the supplied attributes' do
       expect(subject.steps[:slots_step]).
         to have_attributes(option_0: '2015-01-02T09:00/10:00')
+    end
+
+    # For example if the visitor changes the prisoner
+    context 'when the slot is no longer a bookable slot' do
+      before do
+        allow_any_instance_of(BookingConstraints::SlotConstraints).
+          to receive(:bookable_slot?).and_return(false)
+      end
+
+      it { expect(subject.step_name).to eq(:slots_step) }
+      it_behaves_like 'it is incomplete'
     end
 
     it_behaves_like 'it has all steps'


### PR DESCRIPTION
This fixes a bug (server error) when the visitor changes the prison after she
has selected a slot. It fixes this by validating the selected slots are bookable slots according to the prison rules.

Now when a prison is amended the visitor is taken the pick a slot page with no slots selected, which is the same behaviour as in PVB2