### PR TITLE
Remove unnecessary validate method alias

### DIFF
--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -57,8 +57,6 @@ class VisitorsStep
     self.visitors = pruned.empty? ? [{}] : pruned
   end
 
-  alias_method :validate, :valid?
-
   def additional_visitor_count
     visitors.count - 1
   end

--- a/spec/models/feedback_submission_spec.rb
+++ b/spec/models/feedback_submission_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe FeedbackSubmission, type: :model do
     describe 'email_address' do
       it 'is valid when absent' do
         subject.email_address = ''
-        subject.validate
+        subject.valid?
         expect(subject.errors).not_to have_key(:email_address)
       end
 
@@ -48,7 +48,7 @@ RSpec.describe FeedbackSubmission, type: :model do
 
         it 'is valid' do
           subject.email_address = 'user@test.example.com'
-          subject.validate
+          subject.valid?
           expect(subject.errors).not_to have_key(:email_address)
         end
       end
@@ -61,7 +61,7 @@ RSpec.describe FeedbackSubmission, type: :model do
 
         it 'is invalid when not an email address' do
           subject.email_address = 'BOGUS !'
-          subject.validate
+          subject.valid?
           expect(subject.errors).to have_key(:email_address)
         end
       end

--- a/spec/models/slots_step_spec.rb
+++ b/spec/models/slots_step_spec.rb
@@ -33,21 +33,19 @@ RSpec.describe SlotsStep, type: :model do
 
     it 'is valid if the option is a correctly formatted time range' do
       subject.option_0 = '2015-01-02T09:00/10:00'
-      subject.validate
       expect(subject).to be_valid
       expect(subject.errors).not_to have_key(:option_0)
     end
 
     it 'is invalid if the option is not a time range' do
       subject.option_0 = '2015-01-02T09:00'
-      subject.validate
       expect(subject).not_to be_valid
       expect(subject.errors).to have_key(:option_0)
     end
 
     it 'is invalid if option_0 is empty' do
       subject.option_0 = ''
-      subject.validate
+      subject.valid?
       expect(subject.errors).to have_key(:option_0)
     end
 
@@ -55,7 +53,7 @@ RSpec.describe SlotsStep, type: :model do
       subject.option_0 = '2015-01-02T09:00/11:00'
       subject.option_1 = '2015-01-02T09:00/12:00'
       subject.option_2 = '2015-01-02T09:00/13:00'
-      subject.validate
+      subject.valid?
       expect(subject.errors).to have_key(:option_0)
       expect(subject.errors).to have_key(:option_1)
       expect(subject.errors).to have_key(:option_2)
@@ -63,13 +61,13 @@ RSpec.describe SlotsStep, type: :model do
 
     it 'is valid if option_1 is empty' do
       subject.option_1 = ''
-      subject.validate
+      subject.valid?
       expect(subject.errors).not_to have_key(:option_1)
     end
 
     it 'is valid if option_2 empty' do
       subject.option_2 = ''
-      subject.validate
+      subject.valid?
       expect(subject.errors).not_to have_key(:option_2)
     end
   end

--- a/spec/models/visitors_step_spec.rb
+++ b/spec/models/visitors_step_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe VisitorsStep do
         '0' => blank_visitor,
         '1' => blank_visitor
       }
-      subject.validate
+      subject.valid?
       expect(subject.backfilled_visitors[1].errors).to be_empty
     end
   end
@@ -211,7 +211,7 @@ RSpec.describe VisitorsStep do
     it 'validates all objects even if one is invalid' do
       subject.email_address = 'invalid'
       subject.visitors = [invalid_visitor, invalid_visitor]
-      subject.validate
+      subject.valid?
       expect(subject.backfilled_visitors[0].errors).not_to be_empty
       expect(subject.backfilled_visitors[1].errors).not_to be_empty
       expect(subject.errors).not_to be_empty
@@ -222,7 +222,6 @@ RSpec.describe VisitorsStep do
       subject.visitors = [adult_without_dob]
 
       expect(pvb_api).not_to receive(:validate_visitors)
-      subject.validate
       expect(subject).not_to be_valid
       expect(subject.errors[:base]).to eq(
         ["One or more visitors are invalid"]


### PR DESCRIPTION
Confusing, as evidenced by tests calling valid? twice unwittingly.