### PR TITLE
Fix bug with cancelled visits page

### DIFF
--- a/app/models/visit.rb
+++ b/app/models/visit.rb
@@ -20,8 +20,7 @@ class Visit
     visitors.map { |v| Visitor.new(v) }
   }
   attribute :cancellation_reason, Symbol
-  attribute :created_at, DateTime
-  attribute :updated_at, DateTime
+  attribute :cancelled_at, DateTime
 
   VALID_STATES = %i[ requested withdrawn booked cancelled rejected ]
 

--- a/app/views/visits/cancelled.html.erb
+++ b/app/views/visits/cancelled.html.erb
@@ -27,7 +27,7 @@
     <dl>
       <dt><%= t('.cancelled_on') %></dt>
       <dd>
-        <strong><%= @visit.updated_at.to_s(:short) %></strong>
+        <strong><%= @visit.cancelled_at.to_s(:short) %></strong>
       </dd>
     </dl>
   </div>


### PR DESCRIPTION
We started by using update_at during development but we changed it to have a
more explicit cancelled_at instead during review. Looks like public didn't get
updated accordingly.