### PR TITLE
Handle API 404

### DIFF
--- a/app/controllers/visits_controller.rb
+++ b/app/controllers/visits_controller.rb
@@ -2,5 +2,7 @@ class VisitsController < ApplicationController
   def show
     @visit = PrisonVisits::Api.instance.get_visit(params[:id])
     render @visit.processing_state.to_s
+  rescue PrisonVisits::APINotFound
+    render 'errors/404', status: :not_found
   end
 end

--- a/app/services/prison_visits/client.rb
+++ b/app/services/prison_visits/client.rb
@@ -1,7 +1,8 @@
 require 'excon'
 
 module PrisonVisits
-  APIError = Class.new(StandardError)
+  APIError    = Class.new(StandardError)
+  APINotFound = Class.new(StandardError)
 
   class Client
     TIMEOUT = 2 # seconds
@@ -63,6 +64,8 @@ module PrisonVisits
       }
 
       JSON.parse(response.body)
+    rescue Excon::Errors::NotFound
+      raise APINotFound, api_method
     rescue Excon::Errors::HTTPStatusError => e
       body = e.response.body
 

--- a/spec/controllers/visits_controller_spec.rb
+++ b/spec/controllers/visits_controller_spec.rb
@@ -4,20 +4,33 @@ RSpec.describe VisitsController, type: :controller do
   describe 'show' do
     let(:visit) { instance_double(Visit, id: '123456789', processing_state: :rejected) }
 
-    before do
-      expect(pvb_api).to receive(:get_visit).with(visit.id).and_return(visit)
-    end
-
-    it 'calls the get visit API' do
-      get :show, id: visit.id, locale: 'en'
-      expect(assigns(:visit)).to eq(visit)
-    end
-
-    context "rendering views" do
+    context "without errors" do
       render_views
 
-      it 'without errors' do
+      before do
+        expect(pvb_api).to receive(:get_visit).with(visit.id).and_return(visit)
+      end
+
+      it 'calls the get visit API' do
+        get :show, id: visit.id, locale: 'en'
+        expect(assigns(:visit)).to eq(visit)
+      end
+
+      it 'rendering views' do
         expect { get :show, id: visit.id, locale: 'en' }.to_not raise_error
+      end
+    end
+
+    context 'with a non existent visit' do
+      let(:visit_id) { 'i_dont_exsit' }
+      before do
+        expect(pvb_api).to receive(:get_visit).with(visit_id).and_raise(PrisonVisits::APINotFound)
+      end
+
+      it 'renders a 404' do
+        get :show, id: visit_id, locale: 'en'
+        expect(response).to render_template('404')
+        expect(response).to be_not_found
       end
     end
   end

--- a/spec/fixtures/vcr_cassettes/client_json_error.yml
+++ b/spec/fixtures/vcr_cassettes/client_json_error.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3000/api/prisons/missing
+    uri: http://localhost:3000/api/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb
     body:
       encoding: US-ASCII
       string: ''
@@ -17,7 +17,7 @@ http_interactions:
       - unique_id
   response:
     status:
-      code: 404
+      code: 401
       message: ''
     headers:
       X-Frame-Options:
@@ -33,10 +33,10 @@ http_interactions:
       X-Request-Id:
       - unique_id
       X-Runtime:
-      - '0.012952'
+      - '0.037716'
     body:
       encoding: UTF-8
-      string: '{"message":"Not found"}'
+      string: '{"message":"get off my back"}'
     http_version: 
-  recorded_at: Thu, 05 May 2016 15:53:40 GMT
+  recorded_at: Wed, 21 Sep 2016 15:05:37 GMT
 recorded_with: VCR 3.0.1

--- a/spec/fixtures/vcr_cassettes/client_not_found.yml
+++ b/spec/fixtures/vcr_cassettes/client_not_found.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:3000/api/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb
+    uri: http://localhost:3000/api/prisons/missing
     body:
       encoding: US-ASCII
       string: ''
@@ -17,7 +17,7 @@ http_interactions:
       - unique_id
   response:
     status:
-      code: 401
+      code: 404
       message: ''
     headers:
       X-Frame-Options:
@@ -33,15 +33,15 @@ http_interactions:
       X-Request-Id:
       - unique_id
       X-Runtime:
-      - '0.005497'
+      - '0.070579'
     body:
       encoding: UTF-8
-      string: '{"message":"get off my back"}'
+      string: '{"message":"Not found"}'
     http_version: 
-  recorded_at: Wed, 21 Sep 2016 15:11:06 GMT
+  recorded_at: Wed, 21 Sep 2016 15:43:25 GMT
 - request:
     method: get
-    uri: http://localhost:3000/api/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb
+    uri: http://localhost:3000/api/prisons/missing
     body:
       encoding: US-ASCII
       string: ''
@@ -56,7 +56,7 @@ http_interactions:
       - unique_id
   response:
     status:
-      code: 401
+      code: 404
       message: ''
     headers:
       X-Frame-Options:
@@ -72,15 +72,15 @@ http_interactions:
       X-Request-Id:
       - unique_id
       X-Runtime:
-      - '0.005328'
+      - '0.007610'
     body:
       encoding: UTF-8
-      string: '{"message":"get off my back"}'
+      string: '{"message":"Not found"}'
     http_version: 
-  recorded_at: Wed, 21 Sep 2016 15:11:06 GMT
+  recorded_at: Wed, 21 Sep 2016 15:43:25 GMT
 - request:
     method: get
-    uri: http://localhost:3000/api/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb
+    uri: http://localhost:3000/api/prisons/missing
     body:
       encoding: US-ASCII
       string: ''
@@ -95,7 +95,7 @@ http_interactions:
       - unique_id
   response:
     status:
-      code: 401
+      code: 404
       message: ''
     headers:
       X-Frame-Options:
@@ -111,10 +111,10 @@ http_interactions:
       X-Request-Id:
       - unique_id
       X-Runtime:
-      - '0.005124'
+      - '0.006821'
     body:
       encoding: UTF-8
-      string: '{"message":"get off my back"}'
+      string: '{"message":"Not found"}'
     http_version: 
-  recorded_at: Wed, 21 Sep 2016 15:11:06 GMT
+  recorded_at: Wed, 21 Sep 2016 15:43:25 GMT
 recorded_with: VCR 3.0.1

--- a/spec/services/prison_visits/client_spec.rb
+++ b/spec/services/prison_visits/client_spec.rb
@@ -18,8 +18,8 @@ RSpec.describe PrisonVisits::Client do
   describe 'error handling' do
     it 'parses returned JSON errors', vcr: { cassette_name: 'client_json_error' } do
       expect {
-        subject.get('/prisons/missing', idempotent: false)
-      }.to raise_error(PrisonVisits::APIError, 'Unexpected status 404 calling GET /api/prisons/missing: {"message"=>"Not found"}')
+        subject.get('/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb', idempotent: false)
+      }.to raise_error(PrisonVisits::APIError, 'Unexpected status 401 calling GET /api/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb: {"message"=>"get off my back"}')
     end
 
     it 'handles non-JSON error gracefully' do
@@ -41,10 +41,18 @@ RSpec.describe PrisonVisits::Client do
 
     it 'retries idempotent methods by default', vcr: { cassette_name: 'client_json_error_idempotent' } do
       expect {
-        subject.get('/prisons/missing')
-      }.to raise_error(PrisonVisits::APIError, 'Unexpected status 404 calling GET /api/prisons/missing: {"message"=>"Not found"}')
+        subject.get('/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb')
+      }.to raise_error(PrisonVisits::APIError, 'Unexpected status 401 calling GET /api/prisons/ff6eb0ca-da69-4495-ac9d-b383e01371eb: {"message"=>"get off my back"}')
 
       expect(a_request(:get, /\w/)).to have_been_made.times(3)
+    end
+
+    context 'Resource Not Found', vcr: { cassette_name: 'client_not_found' } do
+      it "raises a PrisonVisits::APINotFound" do
+        expect {
+          subject.get('/prisons/missing')
+        }.to raise_error(PrisonVisits::APINotFound, 'GET /api/prisons/missing')
+      end
     end
   end
 end


### PR DESCRIPTION
**CHANGES:**
VisitsController now handle gracefully 404 API and doesn't send to sentry