### PR TITLE
Fix switching locale to cy

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -41,7 +41,7 @@ private
 
   def set_locale
     locale = params[:locale]
-    I18n.locale = if locale && I18n.available_locales.include?(locale)
+    I18n.locale = if locale && I18n.available_locales.include?(locale.to_sym)
                     locale
                   else
                     I18n.default_locale

--- a/spec/controllers/application_controller_spec.rb
+++ b/spec/controllers/application_controller_spec.rb
@@ -15,5 +15,13 @@ RSpec.describe ApplicationController do
         }.to_not raise_error
       end
     end
+
+    context 'with a valid locale' do
+      it 'switches the locale' do
+        expect {
+          get :index, locale: 'cy'
+        }.to change { I18n.locale }.to(:cy)
+      end
+    end
   end
 end


### PR DESCRIPTION
We used to have a feature spec covering this but it was disabled at some
point.