### PR TITLE
Fix lost visitor details when reviewing slots

### DIFF
--- a/app/views/booking_requests/slots_step.html.erb
+++ b/app/views/booking_requests/slots_step.html.erb
@@ -9,7 +9,10 @@
 <%= form_for(@steps.fetch(:slots_step),
              url: booking_requests_path,
              html: { class: 'js-SubmitOnce', autocomplete: 'off' }) do |f| %>
-      <%= render('hidden_prisoner_step') %>
+  <%= render('hidden_prisoner_step') %>
+  <% if reviewing? %>
+    <%= render('hidden_visitors_step') %>
+  <% end %>
 
   <div class="SlotPicker" data-today="<%= Time.zone.today %>">
     <div class="grid-row visible--js-enabled">


### PR DESCRIPTION
This would have been caught if the feature specs had run (they are disabled).

We need to decide what to do with the disabled feature specs, either delete them
or enable them and fix them.