### PR TITLE
Fix Excon staff API healthcheck connection failure

### DIFF
--- a/app/services/prison_visits/client.rb
+++ b/app/services/prison_visits/client.rb
@@ -33,7 +33,10 @@ module PrisonVisits
     end
 
     def healthcheck
-      @connection.head(path: 'healthcheck')
+      @connection.head(
+        path: 'healthcheck',
+        persistent: false
+      )
     end
 
   private


### PR DESCRIPTION
The healthcheck on the application uses an excon connection to the
staff API to carry out a healthcheck on its remote endpoint. Currently
this check reuses an existing connection which is causing an intermittent
502 error on the remote API call. This change means that
calls to the remote staff healthcheck API will use a one-off
non-persistent connection.