### PR TITLE
Remove workers from review apps

### DIFF
--- a/app.json
+++ b/app.json
@@ -28,9 +28,6 @@
     }
   },
   "formation": {
-    "worker": {
-      "quantity": 1
-    },
     "web": {
       "quantity": 1
     }


### PR DESCRIPTION
Otherwise heroku tries to run the default rake task for jobs `rake jobs:run`
indefenetely on the review apps.