### PR TITLE
Add js-enabled class to body if doesn't exist

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -29,6 +29,9 @@
 
 (function() {
   'use strict';
+  if (!document.body.classList.contains('js-enabled')) {
+    document.body.className = ((document.body.className) ? document.body.className + ' js-enabled' : 'js-enabled');
+  }
   delete moj.Modules.devs;
   var selectionButtons = new GOVUK.SelectionButtons("label input[type='radio'], label input[type='checkbox']");
   moj.init();


### PR DESCRIPTION
GOVUK template has an inline script to add the 'js-enabled' class to the body. If the script violates CSP then we should add it from our application.js file.