### PR TITLE
Update selenium-webdriver

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,7 +54,7 @@ group :test do
   gem 'capybara'
   gem 'fuubar'
   gem 'launchy'
-  gem 'selenium-webdriver', '~> 2.53.4'
+  gem 'selenium-webdriver'
   gem 'simplecov'
   gem 'simplecov-rcov'
   gem 'vcr'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
-    childprocess (0.7.0)
+    childprocess (0.7.1)
       ffi (~> 1.0, >= 1.0.11)
     coderay (1.1.1)
     coercible (1.0.0)
@@ -239,10 +239,9 @@ GEM
       tilt (>= 1.1, < 3)
     secure_headers (3.6.5)
       useragent
-    selenium-webdriver (2.53.4)
+    selenium-webdriver (3.4.4)
       childprocess (~> 0.5)
       rubyzip (~> 1.0)
-      websocket (~> 1.0)
     sentry-raven (2.6.0)
       faraday (>= 0.7.6, < 1.0)
     shoulda-matchers (3.1.2)
@@ -289,7 +288,6 @@ GEM
       addressable (>= 2.3.6)
       crack (>= 0.3.2)
       hashdiff
-    websocket (1.2.4)
     websocket-driver (0.6.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.2)
@@ -338,7 +336,7 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails
   secure_headers
-  selenium-webdriver (~> 2.53.4)
+  selenium-webdriver
   sentry-raven (~> 2.6.0)
   shoulda-matchers
   simplecov
@@ -356,4 +354,4 @@ RUBY VERSION
    ruby 2.3.0p0
 
 BUNDLED WITH
-   1.15.1
+   1.15.2

--- a/circle.yml
+++ b/circle.yml
@@ -2,8 +2,19 @@ machine:
   ruby:
     version:
       2.3.0
-  pre:
-    - sudo curl --output /usr/local/bin/phantomjs https://s3.amazonaws.com/circle-downloads/phantomjs-2.1.1
+  environment:
+    PATH: "${PATH}:${HOME}/${CIRCLE_PROJECT_REPONAME}/drivers"
+
 test:
   override:
     - bundle exec rake
+
+dependencies:
+  post:
+    - sudo apt-get update
+    - sudo apt-get install libpango1.0-0
+    - sudo apt-get install firefox
+    - sudo ln -sf /usr/lib/firefox/firefox /usr/bin/firefox
+    - mkdir drivers
+    - wget https://github.com/mozilla/geckodriver/releases/download/v0.18.0/geckodriver-v0.18.0-linux64.tar.gz && tar -zxvf geckodriver-v0.18.0-linux64.tar.gz:
+        pwd: drivers


### PR DESCRIPTION
To latest version (3.4.4) which supports latest Firefox version (54).

`geckodriver` must be in the path, can be installed with homebrew.

`brew install geckodriver`