### PR TITLE
Fix JS race conditon in prison autocomplete

### DIFF
--- a/spec/features/submit_feedback_spec.rb
+++ b/spec/features/submit_feedback_spec.rb
@@ -39,7 +39,7 @@ RSpec.feature 'Submit feedback', js: true do
     fill_in 'Day', with: prisoner_dob_day
     fill_in 'Month', with: prisoner_dob_month
     fill_in 'Year', with: prisoner_dob_year
-    select_prison prison_name, '#feedback_submission_prison_id'
+    select_prison prison_name
     fill_in 'Your email address', with: email_address
 
     click_button 'Send'

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -53,10 +53,9 @@ module FeaturesHelper
     first('#js-slotAvailability input[type="radio"]', visible: false).click
   end
 
-  def select_prison(name, field_id = '#prisoner_step_prison_id')
-    field = find(field_id)
-    field.set(name)
-    field.native.send_keys(:return)
+  def select_prison(name)
+    fill_in 'Prison name', with: name
+    find('.ui-autocomplete a', text: name).click
   end
 
   def check_yes_i_want_to_cancel


### PR DESCRIPTION
We were getting random failures because the prison autocomplete hadn't yet
loaded when we were filling the prison field. This meant that the form was
sending a nil `prison_id`.

The fix is to click on the element from the autocomplete library to ensure that
the JS functionality has loaded and is ready.