### PR TITLE
Remove use of `to_unsafe_h`

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -49,12 +49,49 @@ private
   end
 
   def processor
-    @processor ||= StepsProcessor.new(params, I18n.locale)
+    @processor ||= StepsProcessor.new(sanitised_steps_params.to_h, I18n.locale)
   end
 
   def instrument_booking_request(step_name:, visit: nil)
     PVB::Instrumentation.append_to_log booking_step_rendered: step_name
     PVB::Instrumentation.append_to_log visit_id: visit.id if visit
+  end
+
+  def sanitised_steps_params
+    params.permit(
+      :review_step,
+      prisoner_step: permitted_prisoner_params,
+      visitors_step: permitted_visitors_params,
+      slots_step: permitted_slots_params,
+      confirmation_step: [:confirmed]
+    )
+  end
+
+  def permitted_slots_params
+    %i[option_0 option_1 option_2 currently_filling review_slot skip_remaining_slots]
+  end
+
+  def permitted_prisoner_params
+    [
+      :first_name,
+      :last_name,
+      :number,
+      :prison_id,
+      date_of_birth: %i[day month year]
+    ]
+  end
+
+  def permitted_visitors_params
+    [
+      :email_address,
+      :phone_no,
+      :additional_visitor_count,
+      visitors_attributes: [
+        :first_name,
+        :last_name,
+        date_of_birth: %i[day month year]
+      ]
+    ]
   end
 
   def prison

--- a/app/services/steps_processor.rb
+++ b/app/services/steps_processor.rb
@@ -66,7 +66,7 @@ private
 
   def load_step(step_klass, params)
     step_name = step_klass.name.underscore
-    step_params = params.to_unsafe_h.fetch(step_name, {})
+    step_params = params.fetch(step_name, {})
     step_klass.new(step_params.merge(processor: self))
   end
 end

--- a/app/views/booking_requests/_hidden_prisoner_step.html.erb
+++ b/app/views/booking_requests/_hidden_prisoner_step.html.erb
@@ -2,8 +2,12 @@
                      @steps.fetch(:prisoner_step).first_name) %>
 <%= hidden_field_tag('prisoner_step[last_name]',
                      @steps.fetch(:prisoner_step).last_name) %>
-<%= hidden_field_tag('prisoner_step[date_of_birth]',
-                     @steps.fetch(:prisoner_step).date_of_birth) %>
+<%= hidden_field_tag('prisoner_step[date_of_birth][year]',
+                     @steps.fetch(:prisoner_step).date_of_birth.year) %>
+<%= hidden_field_tag('prisoner_step[date_of_birth][month]',
+                     @steps.fetch(:prisoner_step).date_of_birth.month) %>
+<%= hidden_field_tag('prisoner_step[date_of_birth][day]',
+                     @steps.fetch(:prisoner_step).date_of_birth.day) %>
 <%= hidden_field_tag('prisoner_step[number]',
                      @steps.fetch(:prisoner_step).number) %>
 <%= hidden_field_tag('prisoner_step[prison_id]',

--- a/app/views/booking_requests/_hidden_visitors_step.html.erb
+++ b/app/views/booking_requests/_hidden_visitors_step.html.erb
@@ -10,6 +10,10 @@
                        visitor.first_name) %>
   <%= hidden_field_tag("visitors_step[visitors_attributes][#{i}][last_name]",
                        visitor.last_name) %>
-  <%= hidden_field_tag("visitors_step[visitors_attributes][#{i}][date_of_birth]",
-                       visitor.date_of_birth) %>
+  <%= hidden_field_tag("visitors_step[visitors_attributes][#{i}][date_of_birth][year]",
+                       visitor.date_of_birth.year) %>
+  <%= hidden_field_tag("visitors_step[visitors_attributes][#{i}][date_of_birth][month]",
+                       visitor.date_of_birth.month) %>
+  <%= hidden_field_tag("visitors_step[visitors_attributes][#{i}][date_of_birth][day]",
+                       visitor.date_of_birth.day) %>
 <% end %>

--- a/spec/services/steps_processor_spec.rb
+++ b/spec/services/steps_processor_spec.rb
@@ -60,7 +60,7 @@ RSpec.describe StepsProcessor do
     allow(pvb_api).to receive(:validate_visitors).and_return('valid' => true)
   end
 
-  subject { described_class.new(ActionController::Parameters.new(params), :cy) }
+  subject { described_class.new(params, :cy) }
 
   shared_examples 'it has all steps' do
     it 'has a PrisonerStep' do
@@ -95,7 +95,10 @@ RSpec.describe StepsProcessor do
   end
 
   context 'with incomplete prisoner details' do
-    let(:params) { { prisoner_step: { first_name: 'Oscar' } } }
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.
+        new(prisoner_step: { first_name: 'Oscar' })
+    end
 
     it 'chooses the prisoner_step template' do
       expect(subject.step_name).to eq(:prisoner_step)
@@ -111,7 +114,10 @@ RSpec.describe StepsProcessor do
   end
 
   context 'with complete prisoner details' do
-    let(:params) { { prisoner_step: prisoner_details } }
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.
+        new(prisoner_step: prisoner_details)
+    end
 
     it 'chooses the slots_step template' do
       expect(subject.step_name).to eq(:slots_step)
@@ -135,13 +141,13 @@ RSpec.describe StepsProcessor do
   end
 
   context 'with incomplete visitor details' do
-    let(:params) {
-      {
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.new(
         prisoner_step: prisoner_details,
         slots_step: slots_details,
         visitors_step: { phone_no: '07900112233' }
-      }
-    }
+      )
+    end
 
     it 'chooses the visitors_step template' do
       expect(subject.step_name).to eq(:visitors_step)
@@ -162,13 +168,13 @@ RSpec.describe StepsProcessor do
   end
 
   context 'with complete visitor details' do
-    let(:params) {
-      {
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.new(
         prisoner_step: prisoner_details,
         visitors_step: visitors_details,
         slots_step: slots_details
-      }
-    }
+      )
+    end
 
     it 'chooses the slots_step template' do
       expect(subject.step_name).to eq(:confirmation_step)
@@ -202,12 +208,12 @@ RSpec.describe StepsProcessor do
   end
 
   context 'with at least one slot' do
-    let(:params) {
-      {
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.new(
         prisoner_step: prisoner_details,
         slots_step: slots_details
-      }
-    }
+      )
+    end
 
     before do
       allow_any_instance_of(SlotConstraints).
@@ -244,12 +250,12 @@ RSpec.describe StepsProcessor do
   end
 
   context 'with no slots selected' do
-    let(:params) {
-      {
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.new(
         prisoner_step: prisoner_details,
         slots_step: { option_0: '' }
-      }
-    }
+      )
+    end
 
     it 'chooses the slots_step template' do
       expect(subject.step_name).to eq(:slots_step)
@@ -265,14 +271,14 @@ RSpec.describe StepsProcessor do
   end
 
   context 'after confirming' do
-    let(:params) {
-      {
+    let(:params) do
+      ActiveSupport::HashWithIndifferentAccess.new(
         prisoner_step: prisoner_details,
         visitors_step: visitors_details,
         slots_step: slots_details,
         confirmation_step: { confirmed: 'true' }
-      }
-    }
+      )
+    end
 
     let(:booking_request_creator) {
       double(BookingRequestCreator)


### PR DESCRIPTION
To do so it was necessary to normalise the way that date of births parameters
were being submitted to always use the day/month/year individual parameters,
otherwise is not possible to easiliy use permitted parameters.