### PR TITLE
Fix August calendar IE8 issue

### DIFF
--- a/app/assets/javascripts/modules/moj.booking-calendar.js
+++ b/app/assets/javascripts/modules/moj.booking-calendar.js
@@ -124,7 +124,7 @@
       this.curYear = this.dateObj.getFullYear();
       this.year = this.curYear;
       var firstDate = this.availableSlots[0].date.split('-');
-      this.curMonth = new Date(firstDate[0], parseInt(firstDate[1]) - 1, firstDate[2]).getMonth();
+      this.curMonth = new Date(firstDate[0], parseInt(firstDate[1], 10) - 1, firstDate[2]).getMonth();
       this.month = this.curMonth;
       this.currentDate = false;
       this.date = this.dateObj.getDate();


### PR DESCRIPTION
IE8 is parses ints as base 8 by default, this caused the calendar to display
December 2017 now that we are in August.