### PR TITLE
Fix 'invalid-JSON' bug

### DIFF
--- a/app/services/prison_visits/client.rb
+++ b/app/services/prison_visits/client.rb
@@ -42,9 +42,7 @@ module PrisonVisits
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
     def request(method, route, params:, idempotent:)
-      # For cleanliness, strip initial / if supplied
-      route = route.sub(%r{^\/}, '')
-      path = "/api/#{route}"
+      path = "/api/#{sanitise_route(route)}"
       api_method = "#{method.to_s.upcase} #{path}"
 
       options = {
@@ -95,6 +93,16 @@ module PrisonVisits
           headers: { 'Content-Type' => 'application/json' }
         }
       end
+    end
+
+    def sanitise_route(route)
+      uri_parts = route.split('/')
+      uri_parts = uri_parts.map { |part| CGI.escape(part) }.join('/')
+      strip_initial_forward_slash(uri_parts)
+    end
+
+    def strip_initial_forward_slash(path)
+      path.sub(%r{^\/}, '')
     end
   end
 end

--- a/spec/fixtures/vcr_cassettes/encode_url.yml
+++ b/spec/fixtures/vcr_cassettes/encode_url.yml
@@ -1,0 +1,150 @@
+---
+http_interactions:
+- request:
+    method: get
+    uri: http://localhost:3000/api/visits/much+ado+about+nothing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.58.0
+      Accept:
+      - application/json
+      Accept-Language:
+      - en
+      X-Request-Id:
+      - 5cd2ef1a-4b7e-11e7-a919-92ebcb67fe33
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 5cd2ef1a-4b7e-11e7-a919-92ebcb67fe33
+      X-Runtime:
+      - '0.013046'
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self''; font-src ''self'' data:; img-src
+        ''self'' data: www.google-analytics.com; script-src ''self'' www.google-analytics.com
+        www.gstatic.com docs.google.com ''unsafe-eval'' ''sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=''
+        ''sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='' ''sha256-9GTWoKmlaDM3V+GStWlXFaD4tf+wPfBN2ds2eySQ9aE=''
+        ; style-src ''self'' www.gstatic.com'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not found"}'
+    http_version: 
+  recorded_at: Thu, 28 Sep 2017 08:47:53 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/api/visits/much+ado+about+nothing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.58.0
+      Accept:
+      - application/json
+      Accept-Language:
+      - en
+      X-Request-Id:
+      - 5cd2ef1a-4b7e-11e7-a919-92ebcb67fe33
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 5cd2ef1a-4b7e-11e7-a919-92ebcb67fe33
+      X-Runtime:
+      - '0.011035'
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self''; font-src ''self'' data:; img-src
+        ''self'' data: www.google-analytics.com; script-src ''self'' www.google-analytics.com
+        www.gstatic.com docs.google.com ''unsafe-eval'' ''sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=''
+        ''sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='' ''sha256-9GTWoKmlaDM3V+GStWlXFaD4tf+wPfBN2ds2eySQ9aE=''
+        ; style-src ''self'' www.gstatic.com'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not found"}'
+    http_version: 
+  recorded_at: Thu, 28 Sep 2017 08:47:53 GMT
+- request:
+    method: get
+    uri: http://localhost:3000/api/visits/much+ado+about+nothing
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - excon/0.58.0
+      Accept:
+      - application/json
+      Accept-Language:
+      - en
+      X-Request-Id:
+      - 5cd2ef1a-4b7e-11e7-a919-92ebcb67fe33
+  response:
+    status:
+      code: 404
+      message: Not Found
+    headers:
+      Content-Type:
+      - application/json; charset=utf-8
+      Cache-Control:
+      - no-cache
+      X-Request-Id:
+      - 5cd2ef1a-4b7e-11e7-a919-92ebcb67fe33
+      X-Runtime:
+      - '0.017099'
+      Content-Security-Policy:
+      - 'default-src ''self''; connect-src ''self''; font-src ''self'' data:; img-src
+        ''self'' data: www.google-analytics.com; script-src ''self'' www.google-analytics.com
+        www.gstatic.com docs.google.com ''unsafe-eval'' ''sha256-+6WnXIl4mbFTCARd8N3COQmT3bJJmo32N8q8ZSQAIcU=''
+        ''sha256-G29/qSW/JHHANtFhlrZVDZW1HOkCDRc78ggbqwwIJ2g='' ''sha256-9GTWoKmlaDM3V+GStWlXFaD4tf+wPfBN2ds2eySQ9aE=''
+        ; style-src ''self'' www.gstatic.com'
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - sameorigin
+      X-Permitted-Cross-Domain-Policies:
+      - none
+      X-Xss-Protection:
+      - 1; mode=block
+    body:
+      encoding: ASCII-8BIT
+      string: '{"message":"Not found"}'
+    http_version: 
+  recorded_at: Thu, 28 Sep 2017 08:47:53 GMT
+recorded_with: VCR 3.0.3

--- a/spec/services/prison_visits/client_spec.rb
+++ b/spec/services/prison_visits/client_spec.rb
@@ -46,6 +46,12 @@ RSpec.describe PrisonVisits::Client do
       expect(a_request(:get, /\w/)).to have_been_made.times(3)
     end
 
+    it 'encodes the URL', vcr: { cassette_name: 'encode_url' } do
+      expect {
+        subject.get('/visits/much ado about nothing')
+      }.to raise_error(PrisonVisits::APINotFound, 'GET /api/visits/much+ado+about+nothing')
+    end
+
     context 'Resource Not Found', vcr: { cassette_name: 'client_not_found' } do
       it "raises a PrisonVisits::APINotFound" do
         expect {


### PR DESCRIPTION
Encode URL to ensure that the correct error message is displayed.
Previously if a user had included a string in the URL which had
whitespaces between the words it would result in a 400 error.  This was
incorrect and the fix now presents the user with the correct 404 error
view.