### PR TITLE
Fix email validation bug

### DIFF
--- a/app/services/email_checker.rb
+++ b/app/services/email_checker.rb
@@ -28,8 +28,8 @@ private
 
   def format_error
     return :unparseable unless parsed
-    return :domain_dot if domain_dot_error?
     return :malformed unless well_formed_address?
+    return :domain_dot if domain_dot_error?
   end
 
   def mx_records_error
@@ -47,7 +47,7 @@ private
   end
 
   def domain_dot_error?
-    domain&.start_with?('.')
+    domain.start_with?('.') || domain.match(/\.{2,}/)
   end
 
   def well_formed_address?

--- a/app/views/feedback_submissions/new.html.erb
+++ b/app/views/feedback_submissions/new.html.erb
@@ -37,7 +37,7 @@
         Prison.all.map { |p| [p.name, p.id] },
         { prompt: t('.prison_id_prompt') },
         { class: 'js-autocomplete' }) %>
-        <%= single_field(f, :email_address, :text_field, class: 'form-control') %>
+        <%= single_field(f, :email_address, :email_field, class: 'form-control') %>
         <div class="actions">
           <%= f.submit(t('.send'), class: 'button button-primary') %>
         </div>

--- a/spec/services/email_checker_spec.rb
+++ b/spec/services/email_checker_spec.rb
@@ -49,6 +49,12 @@ RSpec.describe EmailChecker do
 
       it_behaves_like 'an invalid address', 'unparseable'
     end
+
+    context 'with two consecutive dots in the domain' do
+      let(:address) { 'user@example.co..uk' }
+
+      it_behaves_like 'an invalid address', 'domain_dot'
+    end
   end
 
   context 'with valid address' do


### PR DESCRIPTION
Whilst there is an MX check that is included in the EmailChecker for
feedback submission it did not raise any errors when there was an
invalid format e.g. "user@example..com".

The first step of the fix was to amend the HTML input type to "email"
In newer browsers this will pick up/prompt the user where an invalid
email format has been added and will prevent submission until corrected.

However, this fix does not work for older browsers and so the
 #domain_dot_error method has been extended to check for two or more
 consecutive dots in the domain; if found an error is raised.