### PR TITLE
Downgrade puma to 3.9.1

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem 'kramdown'
 gem 'lograge'
 gem 'logstash-event'
 gem 'phonelib'
-gem 'puma'
+gem 'puma', '3.9.1' # To test if production issues still happen with previous version
 gem 'sass-rails'
 gem 'govuk_template'
 gem 'govuk_frontend_toolkit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,7 +166,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.0)
-    puma (3.10.0)
+    puma (3.9.1)
     rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -333,7 +333,7 @@ DEPENDENCIES
   phonelib
   pry-byebug
   pry-rails
-  puma
+  puma (= 3.9.1)
   pvb-instrumentation!
   rails (~> 5.1)
   rails-controller-testing


### PR DESCRIPTION
Puma got bumped around the same time we started having production issues.

I have doubts it's the cause of the issue since pvb2 runs the same version and
there are no reported issues.

We can bump the version again if the issue happens again or after a period of no
issues to see if it reoccurs.