### PR TITLE
Bump puma and stop requiring uneeded gems in prod

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,8 +9,8 @@ gem 'kramdown'
 gem 'lograge'
 gem 'logstash-event'
 gem 'phonelib'
-gem 'puma', '3.9.1' # To test if production issues still happen with previous version
-gem 'sass-rails'
+gem 'puma'
+gem 'sass-rails', require: false
 gem 'govuk_template'
 gem 'govuk_frontend_toolkit'
 gem 'govuk_elements_rails'
@@ -34,7 +34,7 @@ gem 'email_address_validation',
   ref: '6ba244a046b37bed02dca25271849513b200f056'
 
 gem 'string_scrubber'
-gem 'uglifier', '~> 2.7.2'
+gem 'uglifier', '~> 2.7.2', require: false
 gem 'uri_template'
 gem 'virtus'
 gem 'secure_headers'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -176,7 +176,7 @@ GEM
     pry-rails (0.3.6)
       pry (>= 0.10.4)
     public_suffix (3.0.0)
-    puma (3.9.1)
+    puma (3.10.0)
     rack (2.0.3)
     rack-test (0.7.0)
       rack (>= 1.0, < 3)
@@ -339,7 +339,7 @@ DEPENDENCIES
   phonelib
   pry-byebug
   pry-rails
-  puma (= 3.9.1)
+  puma
   pvb-instrumentation!
   rails (~> 5.1)
   rails-controller-testing


### PR DESCRIPTION
There is no issue in puma so bump it.

Production doesn't need `uglifier` and `sass-rails` required as it uses
precompiled assets.