### PR TITLE
Not close persistent connection on healthcheck

### DIFF
--- a/app/services/prison_visits/client.rb
+++ b/app/services/prison_visits/client.rb
@@ -33,7 +33,7 @@ module PrisonVisits
     def healthcheck
       @connection.head(
         path: 'healthcheck',
-        persistent: false
+        idempotent: true
       )
     end
 


### PR DESCRIPTION
Passing persistent false closes the connection, this might be the cause of some
of the EOFErrors since the expectation is that is a live persistent connection.