### PR TITLE
Disable Excon sockets thread cache

### DIFF
--- a/app/services/prison_visits/client.rb
+++ b/app/services/prison_visits/client.rb
@@ -4,15 +4,34 @@ module PrisonVisits
   APIError    = Class.new(StandardError)
   APINotFound = Class.new(StandardError)
 
+  # This client is **NOT** thread safe. To be used with a connection pool. See below.
   class Client
     TIMEOUT = 3 # seconds
     EXCON_INSTRUMENT_NAME = 'pvb_api'.freeze
 
     def initialize(host, persistent: true)
       @host = host
+
+      # Sets `thread_safe_sockets` to `false` on the Excon connection. Setting
+      # to `false` disables Excon connection sockets cache for each thread.
+      #
+      # This cache means that there is a socket connection for every Excon
+      # connection object to the PVB API for each Thread. This is to make an
+      # Excon connection thread safe.
+      #
+      # For example if Puma runs with 4 threads, and those threads reuse a
+      # connection pool of 4 Excon connections means that effectevely there can
+      # be up to 16 live connections to the PVB API.
+      #
+      # This cache is unnecessary in our case since:
+      # - we ensure thread safety by using a connection pool
+      # - we end up opening more sockets than necessary (16 vs 4). If we only
+      #   have 4 puma threads we only need 4 sockets
+      # - the cache has a memory leak when there are short lived threads.
       @connection = Excon.new(
         host, persistent: persistent, connect_timeout: TIMEOUT,
               read_timeout: TIMEOUT, write_timeout: TIMEOUT, retry_limit: 3,
+              thread_safe_sockets: false,
               instrumentor: ActiveSupport::Notifications,
               instrumentor_name: EXCON_INSTRUMENT_NAME
       )


### PR DESCRIPTION
This is the cause of the memory leak that we experienced recently.

Every Excon connection has a cache of sockets that ensures that a socket is only
used by a specific thread during its lifetime. This means that 1 Excon
connection might hold any number of open sockets to the same server.

In our case for example if Puma is running with 4 threads, and a connection pool
of 4 Excon connections to the PVB API it means that there will a maximum of 16
HTTP persistent connections.

The issue is that the implementation of the cache doesn't clear old connections
for threads that are no longer running (an issue when Puma is configured to
autoscale threads). We inadevertedly solved the memory leak by configuring Puma
to use a fixed number of threads.

The implementation of this cache was changed just before we started having
memory leaks to fix a use case of Excon that we don't use. The old
implementation didn't have a memory leak with our use case.

Although this makes the `PrisonVisits::Client` not thread safe it's fine in our
use case because:

 - we use a connection pool of connections and a connection is only used by 1
   thread at a time.
 - It means that we don't hold sockets open unnecessarily for each Excon
   connection.

I've tested the value of this setting locally by load testing the server with
concurrent requests:

  - with the cache enabled and Puma autoscaling threads it showed the memory
    leak when spacing the load testing by 1 minute between benchmarks
  - with the cache disabled and Puma autoscaling threads memory usage remained
    stable and there were no threading issues.

Excon [discussion](https://github.com/excon/excon/issues/640) about the recent
change to the cache where it actually mentions that it has an memory leak issue.