### PR TITLE
Enforce SSL only in Heroku

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -12,7 +12,7 @@ Rails.application.configure do
   config.active_support.deprecation = :notify
   config.log_formatter = ::Logger::Formatter.new
 
-  config.force_ssl = true
+  config.force_ssl = true if ENV.key?('HEROKU_APP_NAME')
 
   config.lograge.formatter = Lograge::Formatters::Logstash.new
   config.lograge.logger = ActiveSupport::Logger.new \


### PR DESCRIPTION
Enforcing SSL with the Rails setting breaks staging and possibly production.

Staging and Production already enforce SSL, so set it only for Heroku.