### PR TITLE
Update email validation & pvb instrumentation gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -26,11 +26,10 @@ gem 'request_store'
 gem 'sentry-raven', '~> 2.7.2'
 gem 'pvb-instrumentation',
   git: 'https://github.com/ministryofjustice/pvb-instrumentation.git',
-  ref: 'a264627211f2bf68f4e388200b2a050fe9081504'
-
+  tag: 'v1.0.1'
 gem 'email_address_validation',
   git: 'https://github.com/ministryofjustice/email_address_validation',
-  ref: 'c19178437958c53fa41fcd54b4ecebe9f8e6a2cf'
+  ref: '5ed2fb93f8d5bc419f03cecb408c688c5bd9fd74'
 
 gem 'string_scrubber'
 gem 'uglifier', '~> 2.7.2', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,19 +9,19 @@ GIT
 
 GIT
   remote: https://github.com/ministryofjustice/email_address_validation
-  revision: c19178437958c53fa41fcd54b4ecebe9f8e6a2cf
-  ref: c19178437958c53fa41fcd54b4ecebe9f8e6a2cf
+  revision: 5ed2fb93f8d5bc419f03cecb408c688c5bd9fd74
+  ref: 5ed2fb93f8d5bc419f03cecb408c688c5bd9fd74
   specs:
-    email_address_validation (0.1.0)
+    email_address_validation (0.1.1)
       activesupport (~> 5.X)
       mail (~> 2.6.6)
 
 GIT
   remote: https://github.com/ministryofjustice/pvb-instrumentation.git
-  revision: a264627211f2bf68f4e388200b2a050fe9081504
-  ref: a264627211f2bf68f4e388200b2a050fe9081504
+  revision: 5696f5a3658701f2a3e1536a9622d828d6c6eb81
+  tag: v1.0.1
   specs:
-    pvb-instrumentation (1.0.0)
+    pvb-instrumentation (1.0.1)
       activesupport (> 4.2)
       request_store (~> 1.3.2)
 
@@ -354,4 +354,4 @@ RUBY VERSION
    ruby 2.4.2p198
 
 BUNDLED WITH
-   1.16.0
+   1.16.1


### PR DESCRIPTION
Following a bundler update it has become necessary to update the
email_addres_validation and pvb_instrumentation gems to include a valid
HTTP URL in the gemspec file.  As these versions have been updated we
need to update the gemfiles of those projects using the gems.