### PR TITLE
Update guidance on storing personal information

### DIFF
--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -281,9 +281,6 @@ en:
         -   how you got to the site
         -   what you click on while you’re visiting the site
 
-        We don’t collect or store your personal information (eg your name or
-        address) so this information can’t be used to identify who you are.
-
         We don’t allow Google to use or share our analytics data.
 
         Google Analytics sets the following cookies:


### PR DESCRIPTION
https://trello.com/c/H3E8BXpZ/1278-cookies-page-says-the-service-does-not-store-prisoner-and-visitor-information