### PR TITLE
Update guidance on session cookie on cookies page

### DIFF
--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -304,9 +304,8 @@ en:
 
         ### Session
 
-        The PVB service does not store your prisoner and visitor information.
-        The details you enter are encrypted and temporarily stored on your
-        computer until your booking request is sent.
+        When you use the “Prison Visits Booking” service, we’ll set a cookie to remember your progress through the forms.
+        These cookies don’t store your personal data and are deleted once you’ve completed the transaction.
 
         | Name | Purpose | Expires |
         | ------------------------ |


### PR DESCRIPTION
Mirrors copy on https://send-money-to-prisoner.service.gov.uk/en-gb/cookies/ 

Trello card - https://trello.com/c/H3E8BXpZ/1278-cookies-page-says-the-service-does-not-store-prisoner-and-visitor-information

Note that Welsh translation yet to be updated (currently blocked)