### PR TITLE
Cookies page - change markdown to HTML

### DIFF
--- a/app/views/pages/cookies.html.erb
+++ b/app/views/pages/cookies.html.erb
@@ -1,9 +1,9 @@
 <% content_for :header, t('.title') %>
 
-<div class='Grid'>
-  <div class='Grid-2-3'>
-    <article>
-      <%= markdown t('.body_md') %>
-    </article>
-  </div>
+<div class='grid-row'>
+	<div class='column-two-thirds'>
+		<article>
+			<%= t('.body_html') %>
+		</article>
+	</div>
 </div>

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -188,35 +188,85 @@ cy:
         France\nLlundain SW1H 9AJ Y Deyrnas Unedig\n"
     cookies:
       title: Cwcis
-      body_md: "Mae'r System trefnu i ymweld â rhywun yn y Carchar (PVB) yn rhoi ffeiliau
-        bychain (a elwir yn 'cwcis') ar \neich cyfrifiadur i gasglu gwybodaeth am
-        sut yr ydych yn pori'r safle.\n\nMae cwcis yn cael eu defnyddio i:\n\n-   fesur
-        sut y byddwch yn defnyddio'r wefan fel y gellir ei diweddaru a'i gwella\n
-        \   ar sail eich anghenion\n-   cofio'r hysbysiadau yr ydych wedi'u gweld
-        fel na fyddwn yn eu dangos\n    i chi eto\n\nNi ddefnyddir cwcis PVB i gael
-        gwybod pwy ydych chi'n bersonol. \n\nFel arfer, fe welwch neges ar y safle
-        cyn y byddwn yn storio cwcis ar\neich cyfrifiadur.\n\nI gael gwybod mwy am
-        reoli cwcis [how to manage\ncookies.](http://www.aboutcookies.org/)\n\nSut
-        y defnyddir cwcis ar PVB\n---------------------------\n\n### Mesur y defnydd
-        a wneir o'r wefan (Google Analytics)\n\nRydym yn defnyddio meddalwedd Google
-        Analytics i gasglu gwybodaeth am sut yr ydych yn\ndefnyddio PVB. Rydym yn
-        gwneud hyn i helpu sicrhau bod y safle'n cwrdd ag anghenion\nei defnyddwyr
-        a'n helpu i wneud gwelliannau.\n\nMae Google Analytics yn storio gwybodaeth
-        am:\n\n-   y tudalennau yr ydych wedi ymweld â nhw ar PVB - faint o amser
-        yr ydych wedi'i dreulio ar bob tudalen PVB\n-   sut y daethoch o hyd i'r safle\n-
-        \  beth rydych yn glicio arno tra byddwch ar y safle\n\nNid
-        ydym yn caniatáu Google i ddefnyddio na rhannu ein data dadansoddol.\n\nMae
-        Google Analytics yn gosod y cwcis canlynol:\n\n| Enw | Pwrpas | Dod i ben
-        |\n| ------------------------ |\n| _ga | Pennu'r nifer o ymwelwyr unigryw
-        i'r safle | 2 flynedd |\n\nGallwch ddewis i optio allan rhag defnyddio cwcis
-        Google Analytics [opt out of Google Analytics\ncookies.](https://tools.google.com/dlpage/gaoptout)\n\n###
-        Ein neges rhagarweiniol\n\nEfallai y byddwch yn gweld neges i'ch croesawu
-        pan fyddwch yn ymweld â thudalen PVB am y tro cyntaf.  Byddwn\nyn storio cwci
-        fel bod eich cyfrifiadur yn gwybod eich bod wedi gweld y neges ac i wybod
-        i beidio\nâ'i ddangos i chi eto.\n\n| Enw | Pwrpas | Dod i ben |\n| ------------------------
-        |\n| seen_cookie_message | Cadw neges i roi gwybod i ni eich bod wedi gweld
-        ein neges cwci | 1 mis |\n\n### Sesiwn\n\nPan fyddwch chi’n defnyddio’r gwasanaeth 
-        \"Archebu Ymweliadau Prison\", byddwn yn gosod cwci ar eich cyfrifiadur i 
-        gofio sut yr ydych chi’n symud ymlaen drwy’r ffurflenni.\n\n| Enw | Pwrpas
-        | Dod i ben |\n| ------------------------ |\n| pvbs | Storio manylion carcharor,
-        ymwelydd a manylion yr ymweliad | 20 munud |\n"
+      body_html: |
+        <p>Mae'r System trefnu i ymweld â rhywun yn y Carchar (PVB) yn rhoi ffeiliau bychain (a elwir yn 'cwcis') ar 
+        eich cyfrifiadur i gasglu gwybodaeth am sut yr ydych yn pori'r safle.</p>
+        <p>Mae cwcis yn cael eu defnyddio i:</p>
+        <ul class="list list-bullet">
+          <li>fesur sut y byddwch yn defnyddio'r wefan fel y gellir ei diweddaru a'i gwella ar sail eich anghenion</li>
+          <li>cofio'r hysbysiadau yr ydych wedi'u gweld fel na fyddwn yn eu dangos i chi eto</li>
+        </ul>
+        <div class="panel panel-border-wide">Ni ddefnyddir cwcis PVB i gael gwybod pwy ydych chi’n bersonol.</div>
+        <p><p>Fel arfer, fe welwch neges ar y safle cyn y byddwn yn storio cwcis ar eich cyfrifiadur.</p></p>
+        <p>I gael gwybod mwy am reoli cwcis <a href="http://www.aboutcookies.org/">how to manage cookies.</a></p>
+        <h2 class="heading-large">Sut y defnyddir cwcis ar PVB</h2>
+        <h3 class="heading-medium">Mesur y defnydd a wneir o’r wefan (Google Analytics)</h3>
+        <p>Rydym yn defnyddio meddalwedd Google Analytics i gasglu gwybodaeth am sut yr ydych yn
+        defnyddio PVB. Rydym yn gwneud hyn i helpu sicrhau bod y safle’n cwrdd ag anghenion
+        ei defnyddwyr a’n helpu i wneud gwelliannau.</p>
+        <p>Mae Google Analytics yn storio gwybodaeth am:</p>
+        <ul class="list list-bullet">
+          <li>y tudalennau yr ydych wedi ymweld â nhw ar PVB - faint o amser yr ydych wedi’i dreulio ar bob tudalen PVB</li>
+          <li>sut y daethoch o hyd i’r safle</li>
+          <li>beth rydych yn glicio arno tra byddwch ar y safle</li>
+        </ul>
+        <div class="panel panel-border-wide">Nid ydym yn caniatáu Google i ddefnyddio na rhannu ein data dadansoddol.</div>
+        <p>Mae Google Analytics yn gosod y cwcis canlynol:</p>
+        <table class="responsive">
+          <thead>
+            <tr>
+              <th>Enw</th>
+              <th>Pwrpas</th>
+              <th>Dod i ben</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td aria-label="Name">_ga</td>
+              <td aria-label="Pwrpas">Pennu’r nifer o ymwelwyr unigryw i’r safle</td>
+              <td aria-label="Dod i ben">2 flynedd</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="push-top">Gallwch ddewis i optio allan rhag defnyddio cwcis Google Analytics 
+          <a href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies.</a>
+        </p>
+        <h3 class="heading-medium" id="ein-neges-rhagarweiniol">Ein neges rhagarweiniol</h3>
+        <p>Efallai y byddwch yn gweld neges i’ch croesawu pan fyddwch yn ymweld â thudalen PVB am y tro cyntaf.  Byddwn
+        yn storio cwci fel bod eich cyfrifiadur yn gwybod eich bod wedi gweld y neges ac i wybod i beidio 
+        â’i ddangos i chi eto.</p>
+        <table class="responsive">
+          <thead>
+            <tr>
+              <th>Enw</th>
+              <th>Pwrpas</th>
+              <th>Dod i ben</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td aria-label="Name">seen_cookie_message</td>
+              <td aria-label="Pwrpas">Cadw neges i roi gwybod i ni eich bod wedi gweld ein neges cwci</td>
+              <td aria-label="Dod i ben">1 mis</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3 class="heading-medium" id="sesiwn">Sesiwn</h3>
+        <p>Pan fyddwch chi’n defnyddio’r gwasanaeth “Archebu Ymweliadau Prison”, byddwn yn gosod cwci ar eich cyfrifiadur 
+        i gofio sut yr ydych chi’n symud ymlaen drwy’r ffurflenni.</p>
+        <table class="responsive">
+          <thead>
+            <tr>
+              <th>Enw</th>
+              <th>Pwrpas</th>
+              <th>Dod i ben</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td aria-label="Name">pvbs</td>
+              <td aria-label="Pwrpas">Storio manylion carcharor, ymwelydd a manylion yr ymweliad</td>
+              <td aria-label="Dod i ben">20 munud</td>
+            </tr>
+          </tbody>
+        </table>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -247,66 +247,78 @@ en:
          London SW1H 9AJ United Kingdom
     cookies:
       title: Cookies
-      body_md: |
-        Prison Visits Booking (PVB) puts small files (known as ‘cookies’) onto
-        your computer to collect information about how you browse the site.
-
-        Cookies are used to:
-
-        -   measure how you use the website so it can be updated and improved
-            based on your needs
-        -   remember the notifications you’ve seen so that we don’t show them to
-            you again
-
-        PVB cookies aren’t used to identify you personally.
-
-        You’ll normally see a message on the site before we store a cookie on
-        your computer.
-
-        Find out more about [how to manage
-        cookies.](http://www.aboutcookies.org/)
-
-        How cookies are used on PVB
-        ---------------------------
-
-        ### Measuring website usage (Google Analytics)
-
-        We use Google Analytics software to collect information about how you
-        use PVB. We do this to help make sure the site is meeting the needs of
-        its users and to help us make improvements.
-
-        Google Analytics stores information about:
-
-        -   the pages you visit on PVB – how long you spend on each PVB page
-        -   how you got to the site
-        -   what you click on while you’re visiting the site
-
-        We don’t allow Google to use or share our analytics data.
-
-        Google Analytics sets the following cookies:
-
-        | Name | Purpose | Expires |
-        | ------------------------ |
-        | _ga | Determines the number of unique visitors to the site | 2 years |
-
-        You can [opt out of Google Analytics
-        cookies.](https://tools.google.com/dlpage/gaoptout)
-
-        ### Our introductory message
-
-        You may see a pop-up welcome message when you first visit PVB. We’ll
-        store a cookie so that your computer knows you’ve seen it and knows not
-        to show it again.
-
-        | Name | Purpose | Expires |
-        | ------------------------ |
-        | seen_cookie_message | Saves a message to let us know that you have seen our cookie message | 1 month |
-
-        ### Session
-
-        When you use the “Prison Visits Booking” service, we’ll set a cookie to remember your progress through the forms.
-        These cookies don’t store your personal data and are deleted once you’ve completed the transaction.
-
-        | Name | Purpose | Expires |
-        | ------------------------ |
-        | pvbs | Store prisoner, visitor and visit details | 20 minutes |
+      body_html: |
+        <p>Prison Visits Booking (PVB) puts small files (known as ‘cookies’) onto
+          your computer to collect information about how you browse the site.</p>
+        <p>Cookies are used to:</p>
+        <ul class="list list-bullet">
+          <li>measure how you use the website so it can be updated and improved based on your needs</li>
+          <li>remember the notifications you’ve seen so that we don’t show them to you again</li>
+        </ul>
+        <div class="panel panel-border-wide">PVB cookies aren’t used to identify you personally.</div>
+        <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
+        <p>Find out more about <a href="http://www.aboutcookies.org/">how to manage cookies.</a></p>
+        <h2 class="heading-large" id="how-cookies-are-used-on-pvb">How cookies are used on PVB</h2>
+        <h3 class="heading-medium" id="measuring-website-usage-google-analytics">Measuring website usage (Google Analytics)</h3>
+        <p>We use Google Analytics software to collect information about how you use PVB. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+        <p>Google Analytics stores information about:</p>
+        <ul class="list list-bullet">
+          <li>the pages you visit on PVB – how long you spend on each PVB page</li>
+          <li>how you got to the site</li>
+          <li>what you click on while you’re visiting the site</li>
+        </ul>
+        <div class="panel panel-border-wide">We don’t allow Google to use or share our analytics data.</div>
+        <p>Google Analytics sets the following cookies:</p>
+        <table class="responsive">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Purpose</th>
+              <th>Expires</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td aria-label="Name">_ga</td>
+              <td aria-label="Purpose">Determines the number of unique visitors to the site</td>
+              <td aria-label="Expires">2 years</td>
+            </tr>
+          </tbody>
+        </table>
+        <p class="push-top">You can <a href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies.</a></p>
+        <h3 class="heading-medium" id="our-introductory-message">Our introductory message</h3>
+        <p>You may see a pop-up welcome message when you first visit PVB. We’ll store a cookie so that your computer knows you’ve seen it and knows not to show it again.</p>
+        <table class="responsive">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Purpose</th>
+              <th>Expires</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td aria-label="Name">seen_cookie_message</td>
+              <td aria-label="Purpose">Saves a message to let us know that you have seen our cookie message</td>
+              <td aria-label="Expires">1 month</td>
+            </tr>
+          </tbody>
+        </table>
+        <h3 class="heading-medium" id="session">Session</h3>
+        <p>When you use the “Prison Visits Booking” service, we’ll set a cookie to remember your progress through the forms. These cookies don’t store your personal data and are deleted once you’ve completed the transaction.</p>
+        <table class="responsive">
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Purpose</th>
+              <th>Expires</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr>
+              <td aria-label="Name">pvbs</td>
+              <td aria-label="Purpose">Store prisoner, visitor and visit details</td>
+              <td aria-label="Expires">20 minutes</td>
+            </tr>
+          </tbody>
+        </table>


### PR DESCRIPTION
This will update the styling of the cookies page to be inline with GOVUK. We cannot add class names to markdown so lets change to HTML

Trello card https://trello.com/c/AWu3pOXT/1284-update-public-cookie-tcs-styling