### PR TITLE
Terms page - change markdown to HTML

### DIFF
--- a/app/views/pages/terms_and_conditions.html.erb
+++ b/app/views/pages/terms_and_conditions.html.erb
@@ -1,9 +1,8 @@
 <% content_for :header, t('.title') %>
-
-<div class='Grid'>
-  <div class='Grid-2-3'>
-    <article>
-      <%= markdown t('.body_md') %>
-    </article>
-  </div>
+<div class="grid-row">
+	<div class="column-two-thirds">
+		<article>
+			<%= t('.body_html') %>
+		</article>
+	</div>
 </div>

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -61,131 +61,156 @@ cy:
         llyfr cyfeiriadau neu restr anfonwyr diogel.
     terms_and_conditions:
       title: Telerau ac amodau a pholisi preifatrwydd
-      body_md: "Drwy ddefnyddio'r gwasanaeth digidol hwn i drefnu i ymweld â rhywun
-        yn y carchar, rydych yn cytuno i'n \npolisi preifatrwydd ac i'r telerau ac
-        amodau hyn. Darllenwch yn ofalus, os gwelwch yn dda. \n\nTelerau ac Amodau\n--------------------\n\n###
-        Cyffredinol\n\nMae'r telerau ac amodau hyn yn effeithio ar eich hawliau a'ch
-        atebolrwydd dan y \ngyfraith. Maent yn llywodraethu'r defnydd a wnewch, a'r
-        perthynas gyda'r gwasanaeth\ndigidol i wneud cais i ymweld â rhywun yn y carchar.
-        Nid ydynt yn berthnasol wasanaethau eraill a ddarperir gan \ny Weinyddiaeth
-        Cyfiawnder (Gwasanaeth Carchardai EM), neu i unrhyw adran neu \nwasanaeth
-        arall sy'n gysylltiedig â'r gwasanaeth hwn.\n\nEfallai y byddwn yn diweddaru'r
-        telerau ac amodau hyn o dro i dro. Gall hyn ddigwydd\nos oes newid yn y gyfraith
-        neu i'r ffordd y mae'r gwasanaeth hwn yn gweithio. Os\noes newid, gofynnir
-        i chi gytuno i'r telerau ac amodau\nnewydd y tro nesaf y byddwch yn mewngofnodi,
-        fel y gallwch barhau i ddefnyddio'r\ngwasanaeth hwn. \n\nOs nad ydych yn cytuno
-        i'r telerau ac amodau na'r polisi preifatrwydd a nodir\nyn y ddogfen hon,
-        ni ddylech ddefnyddio'r gwasanaeth hwn.\n\n### Cyfraith berthnasol\n\nBydd
-        y defnydd a wnewch o'r gwasanaeth hwn, ac unrhyw anghydfod sy'n codi yn sgil
-        hynny, \nyn cael ei lywodraethu gan, a'i ddehongli yn unol â chyfreithiau
-        Cymru\na Lloegr, gan gynnwys ond nid yn gyfyngedig i'r canlynol:\n\n-   Deddf
-        Camddefnyddio Cyfrifiaduron 1990\n-   Deddf Diogelu Data 1998\n-   Deddf Galluedd
-        Meddyliol 2005\n\n### Sut i ddefnyddio'r gwasanaeth hwn mewn ffordd gyfrifol
-        \n\nMae peryglon ynghlwm wrth ddefnyddio cyfrifiadur a rennir, megis mewn
-        caffi rhyngrwyd,\ni ddefnyddio'r gwasanaeth hwn. Eich cyfrifoldeb chi yw bod
-        yn ymwybodol o'r peryglon hyn\nac osgoi defnyddio unrhyw gyfrifiadur allai
-        adael eich gwybodaeth bersonol \nar gael i eraill gael mynediad ati. Chi sy'n
-        gyfrifol os byddwch yn dewis \ni adael cyfrifiadur heb ei ddiogelu pan fyddwch
-        yn y broses o wneud cais \ni ymweld â rhywun yn y carchar.\n\nRydym yn gwneud
-        ein gorau glas i wirio a phrofi'r gwasanaeth hwn pa bryd bynnag y byddwn yn\nnewid
-        neu'n diweddaru unrhyw beth. Fodd bynnag, rhaid i chi gymryd camau eich hunan
-        i ofalu a sicrhau nad yw'r \nffordd yr ydych yn cael mynediad at y gwasanaeth
-        hwn yn eich gwneud yn agored i beryglon\nfirysau, codau cyfrifiaduron maleisus
-        neu ffurfiau eraill o ymyrraeth allai\nddifrodi eich system gyfrifiadurol
-        eich hun. \n\nNi ddylech gamddefnyddio ein gwasanaeth drwy gyflwyno firysau,
-        ymwelwyr diwahoddiad,\nmwydod, bomiau rhesymeg neu ddeunydd arall sy'n faleisus
-        neu'n \nniweidiol yn dechnolegol. Ni ddylech geisio cael mynediad heb awdurdod\ni'n
-        gwasanaeth, y system lle cedwir ein gwasanaeth nac unrhyw\nweinydd, cyfrifiadur
-        neu gronfa data sy'n gysylltiedig â'n gwasanaeth. Ni ddylech\nymosod ar ein
-        safle drwy ymosodiad gwrthod gwasanaeth neu ymosodiad atal\ngwasanaeth.\n\nPolisi
-        preifatrwydd\n--------------\n\n### Gwybodaeth a ddarperir gan y gwasanaeth
-        hwn\n\nRydym yn gweithio'n galed i sicrhau bod yr wybodaeth o fewn y gwasanaeth
-        digidol hwn\ni wneud cais i ymweld â rhywun yn y carchar yn gywir. Fodd bynnag,
-        ni allwn sicrhau bod yr wybodaeth yn gywir ac yn gyflawn bob amser.\n\nEr
-        ein bod yn gwneud pob ymdrech i sicrhau bod y gwasanaeth hwn ar gael bob amser,\nnid
-        ydym yn gyfrifol os nad yw ar gael am unrhyw gyfnod penodol. \n\n### Sut rydym
-        yn defnyddio eich gwybodaeth\n\nMae'r Weinyddiaeth Cyfiawnder (Gwasanaeth
-        Carchardai EM) yn defnyddio ac yn cadw\ndata personol ymwelwyr at ddibenion
-        darparu Gwasanaethau Carchardai saff a diogel, \ngan gynnwys y rhai sy'n berthnasol
-        i reoli ac \nadsefydlu troseddwyr.\n\nCaniateir mynediad i'r sefydliad drwy
-        roi'r wybodaeth\ny gofynnir amdani'n unig er mwyn sicrhau ein bod yn cynnal
-        amgylchedd saff a diogel\ni bawb.\n\nMae gennych yr hawl i ofyn am fanylion
-        o ran yr wybodaeth bersonol sydd \ngennym amdanoch chi; ac o ganlyniad, mae
-        gofyn i ni gywiro unrhyw wybodaeth\nbersonol sy'n anghywir neu'n hen. Ni fyddwn
-        yn\nrhannu eich gwybodaeth gyda sefydliadau eraill oni bai ei bod yn ofynnol
-        i ni wneud hynny \nat ddibenion atal, canfod trosedd, arestio,\nerlyn, a rheoli
-        troseddwyr; atal terfysgaeth;\ndiogelwch cenedlaethol; neu fod gofyniad cyfreithiol
-        i wneud hynny.\n\nAr wahân i'r wybodaeth sy'n cael ei fewnbynnu gan y sawl
-        sy'n defnyddio'r gwasanaeth hwn, hefyd\nrydym yn casglu gwybodaeth am y defnydd
-        a wneir o'r safle sy'n ein galluogi i weld sut mae'r \ngwasanaeth yn cael
-        ei ddefnyddio i'n helpu i'w wella. Nid yw'r\nwybodaeth hon yn cynnwys unrhyw
-        ddata personol.\n\nMae'n cynnwys:\n\n-   cwestiynau, ymholiadau neu adborth
-        y byddwch yn ei adael, gan gynnwys eich cyfeiriad\n    e-bost os byddwch yn
-        anfon neges drwy adborth\n-   eich cyfeiriad IP, a manylion y fersiwn o'r
-        porwr gwe a ddefnyddiwyd gennych\n-   gwybodaeth ar sut rydych yn defnyddio'r
-        safle, defnyddio cwcis a thechnegau tagio tudalennau\n    i'n helpu i wella'r
-        wefan\n\nMae hyn yn ein helpu i:\n\n-   wella'r safle drwy fonitro'r ffordd
-        yr ydych yn ei defnyddio\n-   ymateb i unrhyw adborth y byddwch yn ei roi
-        i ni, os ydych wedi gofyn i ni wneud hynny\n-   darparu gwybodaeth am wasanaethau
-        lleol\n\nNid ydym yn gallu canfod pwy ydych chi'n bersonol drwy ddefnyddio
-        eich data.\n\n### Ym mhle mae eich data yn cael ei storio\n\nRydym yn storio
-        eich data ar ein gweinyddwyr diogel yn y DU. Fodd bynnag, efallai y bydd\nyn
-        cael ei storio y tu allan i Ewrop hefyd, i'n staff neu ein darparwyr weld.\nRydych
-        yn cytuno i hyn drwy gyflwyno eich data personol. \n\nHefyd, rydym yn defnyddio
-        cyflenwyr eraill i ddarparu'r gwasanaeth hwn:\n\n-   [SendGrid](http://sendgrid.com)
-        i gyfnewid gwybodaeth â charchardai. Gweler\n    y telerau ac amodau [terms
-        & conditions](http://sendgrid.com/tos) sydd ynghlwm wrth \n    y gwasanaeth
-        hwn.\n-   [ZenDesk](http://www.zendesk.com) i ddelio ag unrhyw adborth y byddwch\n
-        \   yn ei adael. Gweler y telerau ac amodau [terms &\n    conditions](http://www.zendesk.com/company/terms)
-        sydd ynghlwm wrth y gwasanaeth\n   hwn.\n\n### Cadw eich data yn ddiogel\n\nYn
-        gyffredinol, nid yw trosglwyddo gwybodaeth dros y we yn gwbl\nddiogel, ac
-        ni allwn eich gwarantu y cedwir eich data yn ddiogel.  Fodd bynnag, rydym\nyn
-        defnyddio SSL er mwyn amgryptio'r holl ddata sy'n cael ei drosglwyddo i mewn
-        a'r data a dderbynnir \no'n gweinydd.\n\nRydym yn cymryd diogelwch data o
-        ddifrif, ac rydym yn cymryd pob cam i sicrhau\ny cedwir eich data yn breifat
-        ac yn ddiogel.\n\n### Rydych yn cyflwyno unrhyw ddata ar eich menter eich
-        hun.\n\nMae gennym weithdrefnau a nodweddion diogelwch mewn lle i geisio cadw
-        eich\ndata yn ddiogel unwaith y byddwn wedi ei gael.\n\nNi fyddwn yn rhannu
-        eich gwybodaeth gydag unrhyw sefydliadau eraill at ddibenion\nmarchnata, ymchwil
-        marchnad neu ddibenion masnachol ac nid ydym yn anfon\neich manylion ymlaen
-        i wefannau eraill.\n\n### Datgelu eich gwybodaeth\n\nEfallai y byddwn yn anfon
-        eich gwybodaeth bersonol ymlaen os oes gennym ddyletswydd gyfreithiol i wneud
-        hynny.\n\n### Sut rydym yn rheoli sesiynau\n\nGallwch ddefnyddio'r gwasanaeth
-        hwn i wneud cais i ymweld â rhywun yn carchar.  Bydd eich sesiwn yn fyw\nam
-        20 munud, hyd yn oed os byddwch yn cau eich porwr, neu'n llywio i ffwrdd oddi
-        ar y gwasanaeth. Yn ystod y cyfnod hwn, efallai y bydd gwybodaeth bersonol
-        amdanoch chi\nyn weladwy i unrhyw un sydd â mynediad at eich cyfrifiadur.\n\nBydd
-        eich data yn cael ei gadw ar y cof yn ystod eich sesiwn; bydd hyn yn cael\nei
-        glirio 20 munud wedi unrhyw ddiffyg gweithredu.\n\n### Deddf Diogelu Data
-        1998\n\nMae'r gwasanaeth hwn yn cydymffurfio gyda holl egwyddorion Deddf Diogelu
-        Data 1998.\n\nY Weinyddiaeth Cyfiawnder yw'r 'rheolydd data' at ddibenion
-        \ny Ddeddf. Fodd bynnag, nid yw'r wybodaeth yr ydych yn ei rhoi i mewn i'r
-        gwasanaeth hwn\nyn cael ei throsglwyddo'n awtomatig i'r Weinyddiaeth Cyfiawnder,
-        ond mae'n cael ei chadw mewn \ncronfa ddata. Ni fydd unrhyw ddata personol
-        yn ei ddefnyddio wrth brofi'r gwasanaeth hwn.\n\nBydd gan ein darparwr lletya,
-        a staff y Weinyddiaeth Cyfiawnder sy'n gyfrifol am gefnogi'r \ngwasanaeth
-        hwn, fynediad ar y gweinydd lle mae'r holl wybodaeth bersonol yn cael ei \nmewnbynnu
-        a lle cedwir y data ar gyfer y gwasanaeth hwn dros dro. Mae'r holl staff\nsydd
-        â mynediad at y data diogel wedi bod yn destun cliriad diogelwch y Weinyddiaeth
-        Cyfiawnder.\n\nMae gan unrhyw un sy'n credu bod eu data personol yn cael ei
-        gadw o fewn y gwasanaeth hwn\nyr hawl i gyflwyno cais am fynediad at yr wybodaeth
-        i'r Weinyddiaeth Cyfiawnder, a fydd yn rhoi manylion yr wybodaeth a gedwir
-        ar y gweinydd.\n\n### Ymwadiad\n\nNid ydym yn derbyn unrhyw gyfrifoldeb am
-        unrhyw golled neu niwed a achosir o ganlyniad i ddefnyddio'r gwasanaeth hwn,
-        boed yn uniongyrchol, yn anuniongyrchol, pa un ai achosir\nhyn drwy gamwedd,
-        torri cytundeb neu fel arall. Mae hyn yn cynnwys colli incwm neu\nrefeniw,
-        busnes, elw neu gontractau, arbedion a ragwelir, data,\newyllys da, eiddo
-        diriaethol neu amser a wastraffir yng nghyswllt y\ngwasanaeth hwn neu unrhyw
-        wefannau cysylltiedig iddo ac unrhyw ddeunyddiau sy'n cael eu postio arno.\nNi
-        ddylai'r amod hwn atal gwneud hawliad am golled neu ddifrod i'ch\neiddo diriaethol
-        neu unrhyw hawliadau eraill am golled ariannol uniongyrchol nad ydynt\nwedi'i
-        heithrio gan unrhyw un o'r categorïau a nodir uchod.\n\nNid yw hyn yn effeithio
-        ar ein cyfrifoldeb dros farwolaeth neu anaf personol a achosir\no ganlyniad
-        i'n esgeulustod, nac ein cyfrifoldeb dros anwiredd twyllodrus\nneu anwiredd
-        mewn perthynas â mater sylfaenol, nac unrhyw gyfrifoldeb arall\nna ellir ei
-        eithrio neu sy'n gyfyngedig o dan y gyfraith berthnasol.\n\n### Cysylltwch
-        â ni\n\nY Weinyddiaeth Cyfiawnder\nGwasanaethau Digidol, 11.51\n102 Petty
-        France\nLlundain SW1H 9AJ Y Deyrnas Unedig\n"
+      body_html: |
+        <p>Drwy ddefnyddio’r gwasanaeth digidol hwn i drefnu i ymweld â rhywun yn y carchar, rydych yn cytuno i’n
+        polisi preifatrwydd ac i’r telerau ac amodau hyn. Darllenwch yn ofalus, os gwelwch yn dda.</p>
+        <h2 class="heading-large" id="telerau-ac-amodau">Telerau ac Amodau</h2>
+        <h3 class="heading-medium" id="cyffredinol">Cyffredinol</h3>
+        <p>Mae’r telerau ac amodau hyn yn effeithio ar eich hawliau a’ch atebolrwydd dan y
+          gyfraith. Maent yn llywodraethu’r defnydd a wnewch, a’r perthynas gyda’r gwasanaeth
+          digidol i wneud cais i ymweld â rhywun yn y carchar. Nid ydynt yn berthnasol wasanaethau eraill a ddarperir gan
+          y Weinyddiaeth Cyfiawnder (Gwasanaeth Carchardai EM), neu i unrhyw adran neu
+        wasanaeth arall sy’n gysylltiedig â’r gwasanaeth hwn.</p>
+        <p>Efallai y byddwn yn diweddaru’r telerau ac amodau hyn o dro i dro. Gall hyn ddigwydd
+          os oes newid yn y gyfraith neu i’r ffordd y mae’r gwasanaeth hwn yn gweithio. Os
+          oes newid, gofynnir i chi gytuno i’r telerau ac amodau
+          newydd y tro nesaf y byddwch yn mewngofnodi, fel y gallwch barhau i ddefnyddio’r
+        gwasanaeth hwn.</p>
+        <p>Os nad ydych yn cytuno i’r telerau ac amodau na’r polisi preifatrwydd a nodir
+        yn y ddogfen hon, ni ddylech ddefnyddio’r gwasanaeth hwn.</p>
+        <h3 class="heading-medium" id="cyfraith-berthnasol">Cyfraith berthnasol</h3>
+        <p>Bydd y defnydd a wnewch o’r gwasanaeth hwn, ac unrhyw anghydfod sy’n codi yn sgil hynny,
+          yn cael ei lywodraethu gan, a’i ddehongli yn unol â chyfreithiau Cymru
+        a Lloegr, gan gynnwys ond nid yn gyfyngedig i’r canlynol:</p>
+        <ul class="list list-bullet">
+          <li>Deddf Camddefnyddio Cyfrifiaduron 1990</li>
+          <li>Deddf Diogelu Data 1998</li>
+          <li>Deddf Galluedd Meddyliol 2005</li>
+        </ul>
+        <h3 class="heading-medium" id="sut-i-ddefnyddior-gwasanaeth-hwn-mewn-ffordd-gyfrifol">Sut i ddefnyddio’r gwasanaeth hwn mewn ffordd gyfrifol</h3>
+        <p>Mae peryglon ynghlwm wrth ddefnyddio cyfrifiadur a rennir, megis mewn caffi rhyngrwyd,
+          i ddefnyddio’r gwasanaeth hwn. Eich cyfrifoldeb chi yw bod yn ymwybodol o’r peryglon hyn
+          ac osgoi defnyddio unrhyw gyfrifiadur allai adael eich gwybodaeth bersonol
+          ar gael i eraill gael mynediad ati. Chi sy’n gyfrifol os byddwch yn dewis
+          i adael cyfrifiadur heb ei ddiogelu pan fyddwch yn y broses o wneud cais
+        i ymweld â rhywun yn y carchar.</p>
+        <p>Rydym yn gwneud ein gorau glas i wirio a phrofi’r gwasanaeth hwn pa bryd bynnag y byddwn yn
+          newid neu’n diweddaru unrhyw beth. Fodd bynnag, rhaid i chi gymryd camau eich hunan i ofalu a sicrhau nad yw’r
+          ffordd yr ydych yn cael mynediad at y gwasanaeth hwn yn eich gwneud yn agored i beryglon
+          firysau, codau cyfrifiaduron maleisus neu ffurfiau eraill o ymyrraeth allai
+        ddifrodi eich system gyfrifiadurol eich hun.</p>
+        <p>Ni ddylech gamddefnyddio ein gwasanaeth drwy gyflwyno firysau, ymwelwyr diwahoddiad,
+          mwydod, bomiau rhesymeg neu ddeunydd arall sy’n faleisus neu’n
+          niweidiol yn dechnolegol. Ni ddylech geisio cael mynediad heb awdurdod
+          i’n gwasanaeth, y system lle cedwir ein gwasanaeth nac unrhyw
+          weinydd, cyfrifiadur neu gronfa data sy’n gysylltiedig â’n gwasanaeth. Ni ddylech
+          ymosod ar ein safle drwy ymosodiad gwrthod gwasanaeth neu ymosodiad atal
+        gwasanaeth.</p>
+        <h2 class="heading-large" id="polisi-preifatrwydd">Polisi preifatrwydd</h2>
+        <h3 class="heading-medium" id="gwybodaeth-a-ddarperir-gan-y-gwasanaeth-hwn">Gwybodaeth a ddarperir gan y gwasanaeth hwn</h3>
+        <p>Rydym yn gweithio’n galed i sicrhau bod yr wybodaeth o fewn y gwasanaeth digidol hwn
+        i wneud cais i ymweld â rhywun yn y carchar yn gywir. Fodd bynnag, ni allwn sicrhau bod yr wybodaeth yn gywir ac yn gyflawn bob amser.</p>
+        <p>Er ein bod yn gwneud pob ymdrech i sicrhau bod y gwasanaeth hwn ar gael bob amser,
+        nid ydym yn gyfrifol os nad yw ar gael am unrhyw gyfnod penodol.</p>
+        <h3 class="heading-medium" id="sut-rydym-yn-defnyddio-eich-gwybodaeth">Sut rydym yn defnyddio eich gwybodaeth</h3>
+        <p>Mae’r Weinyddiaeth Cyfiawnder (Gwasanaeth Carchardai EM) yn defnyddio ac yn cadw
+          data personol ymwelwyr at ddibenion darparu Gwasanaethau Carchardai saff a diogel,
+          gan gynnwys y rhai sy’n berthnasol i reoli ac
+        adsefydlu troseddwyr.</p>
+        <p>Caniateir mynediad i’r sefydliad drwy roi’r wybodaeth
+          y gofynnir amdani’n unig er mwyn sicrhau ein bod yn cynnal amgylchedd saff a diogel
+        i bawb.</p>
+        <p>Mae gennych yr hawl i ofyn am fanylion o ran yr wybodaeth bersonol sydd
+          gennym amdanoch chi; ac o ganlyniad, mae gofyn i ni gywiro unrhyw wybodaeth
+          bersonol sy’n anghywir neu’n hen. Ni fyddwn yn
+          rhannu eich gwybodaeth gyda sefydliadau eraill oni bai ei bod yn ofynnol i ni wneud hynny
+          at ddibenion atal, canfod trosedd, arestio,
+          erlyn, a rheoli troseddwyr; atal terfysgaeth;
+        diogelwch cenedlaethol; neu fod gofyniad cyfreithiol i wneud hynny.</p>
+        <p>Ar wahân i’r wybodaeth sy’n cael ei fewnbynnu gan y sawl sy’n defnyddio’r gwasanaeth hwn, hefyd
+          rydym yn casglu gwybodaeth am y defnydd a wneir o’r safle sy’n ein galluogi i weld sut mae’r
+          gwasanaeth yn cael ei ddefnyddio i’n helpu i’w wella. Nid yw’r
+        wybodaeth hon yn cynnwys unrhyw ddata personol.</p>
+        <p>Mae’n cynnwys:</p>
+        <ul class="list list-bullet">
+          <li>cwestiynau, ymholiadau neu adborth y byddwch yn ei adael, gan gynnwys eich cyfeiriad
+          e-bost os byddwch yn anfon neges drwy adborth</li>
+          <li>eich cyfeiriad IP, a manylion y fersiwn o’r porwr gwe a ddefnyddiwyd gennych</li>
+          <li>gwybodaeth ar sut rydych yn defnyddio’r safle, defnyddio cwcis a thechnegau tagio tudalennau
+          i’n helpu i wella’r wefan</li>
+        </ul>
+        <p>Mae hyn yn ein helpu i:</p>
+        <ul class="list list-bullet">
+          <li>wella’r safle drwy fonitro’r ffordd yr ydych yn ei defnyddio</li>
+          <li>ymateb i unrhyw adborth y byddwch yn ei roi i ni, os ydych wedi gofyn i ni wneud hynny</li>
+          <li>darparu gwybodaeth am wasanaethau lleol</li>
+        </ul>
+        <p>Nid ydym yn gallu canfod pwy ydych chi’n bersonol drwy ddefnyddio eich data.</p>
+        <h3 class="heading-medium" id="ym-mhle-mae-eich-data-yn-cael-ei-storio">Ym mhle mae eich data yn cael ei storio</h3>
+        <p>Rydym yn storio eich data ar ein gweinyddwyr diogel yn y DU. Fodd bynnag, efallai y bydd
+          yn cael ei storio y tu allan i Ewrop hefyd, i’n staff neu ein darparwyr weld.
+        Rydych yn cytuno i hyn drwy gyflwyno eich data personol.</p>
+        <p>Hefyd, rydym yn defnyddio cyflenwyr eraill i ddarparu’r gwasanaeth hwn:</p>
+        <ul class="list list-bullet">
+          <li><a href="http://sendgrid.com">SendGrid</a> i gyfnewid gwybodaeth â charchardai. Gweler
+            y telerau ac amodau <a href="http://sendgrid.com/tos">terms &amp; conditions</a> sydd ynghlwm wrth
+          y gwasanaeth hwn.</li>
+          <li><a href="http://www.zendesk.com">ZenDesk</a> i ddelio ag unrhyw adborth y byddwch
+            yn ei adael. Gweler y telerau ac amodau <a href="http://www.zendesk.com/company/terms">terms &amp;
+            conditions</a> sydd ynghlwm wrth y gwasanaeth
+          hwn.</li>
+        </ul>
+        <h3 class="heading-medium" id="cadw-eich-data-yn-ddiogel">Cadw eich data yn ddiogel</h3>
+        <p>Yn gyffredinol, nid yw trosglwyddo gwybodaeth dros y we yn gwbl
+          ddiogel, ac ni allwn eich gwarantu y cedwir eich data yn ddiogel.  Fodd bynnag, rydym
+          yn defnyddio SSL er mwyn amgryptio’r holl ddata sy’n cael ei drosglwyddo i mewn a’r data a dderbynnir
+        o’n gweinydd.</p>
+        <p>Rydym yn cymryd diogelwch data o ddifrif, ac rydym yn cymryd pob cam i sicrhau
+        y cedwir eich data yn breifat ac yn ddiogel.</p>
+        <h3 class="heading-medium" id="rydych-yn-cyflwyno-unrhyw-ddata-ar-eich-menter-eich-hun">Rydych yn cyflwyno unrhyw ddata ar eich menter eich hun.</h3>
+        <p>Mae gennym weithdrefnau a nodweddion diogelwch mewn lle i geisio cadw eich
+        data yn ddiogel unwaith y byddwn wedi ei gael.</p>
+        <p>Ni fyddwn yn rhannu eich gwybodaeth gydag unrhyw sefydliadau eraill at ddibenion
+          marchnata, ymchwil marchnad neu ddibenion masnachol ac nid ydym yn anfon
+        eich manylion ymlaen i wefannau eraill.</p>
+        <h3 class="heading-medium" id="datgelu-eich-gwybodaeth">Datgelu eich gwybodaeth</h3>
+        <p>Efallai y byddwn yn anfon eich gwybodaeth bersonol ymlaen os oes gennym ddyletswydd gyfreithiol i wneud hynny.</p>
+        <h3 class="heading-medium" id="sut-rydym-yn-rheoli-sesiynau">Sut rydym yn rheoli sesiynau</h3>
+        <p>Gallwch ddefnyddio’r gwasanaeth hwn i wneud cais i ymweld â rhywun yn carchar.  Bydd eich sesiwn yn fyw
+          am 20 munud, hyd yn oed os byddwch yn cau eich porwr, neu’n llywio i ffwrdd oddi ar y gwasanaeth. Yn ystod y cyfnod hwn, efallai y bydd gwybodaeth bersonol amdanoch chi
+        yn weladwy i unrhyw un sydd â mynediad at eich cyfrifiadur.</p>
+        <p>Bydd eich data yn cael ei gadw ar y cof yn ystod eich sesiwn; bydd hyn yn cael
+        ei glirio 20 munud wedi unrhyw ddiffyg gweithredu.</p>
+        <h3 class="heading-medium" id="deddf-diogelu-data-1998">Deddf Diogelu Data 1998</h3>
+        <p>Mae’r gwasanaeth hwn yn cydymffurfio gyda holl egwyddorion Deddf Diogelu Data 1998.</p>
+        <p>Y Weinyddiaeth Cyfiawnder yw’r ‘rheolydd data’ at ddibenion
+          y Ddeddf. Fodd bynnag, nid yw’r wybodaeth yr ydych yn ei rhoi i mewn i’r gwasanaeth hwn
+          yn cael ei throsglwyddo’n awtomatig i’r Weinyddiaeth Cyfiawnder, ond mae’n cael ei chadw mewn
+        cronfa ddata. Ni fydd unrhyw ddata personol yn ei ddefnyddio wrth brofi’r gwasanaeth hwn.</p>
+        <p>Bydd gan ein darparwr lletya, a staff y Weinyddiaeth Cyfiawnder sy’n gyfrifol am gefnogi’r
+          gwasanaeth hwn, fynediad ar y gweinydd lle mae’r holl wybodaeth bersonol yn cael ei
+          mewnbynnu a lle cedwir y data ar gyfer y gwasanaeth hwn dros dro. Mae’r holl staff
+        sydd â mynediad at y data diogel wedi bod yn destun cliriad diogelwch y Weinyddiaeth Cyfiawnder.</p>
+        <p>Mae gan unrhyw un sy’n credu bod eu data personol yn cael ei gadw o fewn y gwasanaeth hwn
+        yr hawl i gyflwyno cais am fynediad at yr wybodaeth i’r Weinyddiaeth Cyfiawnder, a fydd yn rhoi manylion yr wybodaeth a gedwir ar y gweinydd.</p>
+        <h3 class="heading-medium" id="ymwadiad">Ymwadiad</h3>
+        <p>Nid ydym yn derbyn unrhyw gyfrifoldeb am unrhyw golled neu niwed a achosir o ganlyniad i ddefnyddio’r gwasanaeth hwn, boed yn uniongyrchol, yn anuniongyrchol, pa un ai achosir
+          hyn drwy gamwedd, torri cytundeb neu fel arall. Mae hyn yn cynnwys colli incwm neu
+          refeniw, busnes, elw neu gontractau, arbedion a ragwelir, data,
+          ewyllys da, eiddo diriaethol neu amser a wastraffir yng nghyswllt y
+          gwasanaeth hwn neu unrhyw wefannau cysylltiedig iddo ac unrhyw ddeunyddiau sy’n cael eu postio arno.
+          Ni ddylai’r amod hwn atal gwneud hawliad am golled neu ddifrod i’ch
+          eiddo diriaethol neu unrhyw hawliadau eraill am golled ariannol uniongyrchol nad ydynt
+        wedi’i heithrio gan unrhyw un o’r categorïau a nodir uchod.</p>
+        <p>Nid yw hyn yn effeithio ar ein cyfrifoldeb dros farwolaeth neu anaf personol a achosir
+          o ganlyniad i’n esgeulustod, nac ein cyfrifoldeb dros anwiredd twyllodrus
+          neu anwiredd mewn perthynas â mater sylfaenol, nac unrhyw gyfrifoldeb arall
+        na ellir ei eithrio neu sy’n gyfyngedig o dan y gyfraith berthnasol.</p>
+        <h3 class="heading-medium" id="cysylltwch--ni">Cysylltwch â ni</h3>
+        <p>Y Weinyddiaeth Cyfiawnder
+          Gwasanaethau Digidol, 11.51
+          102 Petty France
+        Llundain SW1H 9AJ Y Deyrnas Unedig</p>
     cookies:
       title: Cwcis
       body_html: |

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -245,6 +245,163 @@ en:
          Digital Services, 11.51
          102 Petty France
          London SW1H 9AJ United Kingdom
+      body_html: |
+        <p>By using this digital prison visit request service you agree to our
+          privacy policy and to these terms and conditions. Please read them
+        carefully.</p>
+        <h2 class="heading-large" id="terms-and-conditions">Terms and conditions</h2>
+        <h3 class="heading-medium" id="general">General</h3>
+        <p>These terms and conditions affect your rights and liabilities under the
+          law. They govern your use of, and relationship with, the digital prison
+          visit request service. They don’t apply to other services provided by
+          the Ministry of Justice (HM Prison Service), or to any other department
+        or service which is linked to in this service.</p>
+        <p>We may occasionally update these terms and conditions. This might happen
+          if there’s a change in the law or to the way this service works. If
+          there’s a change, you’ll be asked to agree to the new terms and
+          conditions the next time you sign in, so you can continue to use this
+        service.</p>
+        <p>If you don’t agree to the terms and conditions and privacy policy set
+        out in this document, you should not use this service.</p>
+        <h3 class="heading-medium" id="applicable-law">Applicable law</h3>
+        <p>Your use of this service and any dispute arising from its use will be
+          governed by and construed in accordance with the laws of England and
+        Wales, including but not limited to the:</p>
+        <ul class="list list-bullet">
+          <li>Computer Misuse Act 1990</li>
+          <li>Data Protection Act 1998</li>
+          <li>Mental Capacity Act 2005</li>
+        </ul>
+        <h3 class="heading-medium" id="how-to-use-this-service-responsibly">How to use this service responsibly</h3>
+        <p>There are risks in using a shared computer, such as in an internet café,
+          to use this service. It’s your responsibility to be aware of these risks
+          and to avoid using any computer which may leave your personal
+          information accessible to others. You are responsible if you choose to
+          leave a computer unprotected while in the process of making a prison
+        visit request.</p>
+        <p>We make every effort to check and test this service whenever we amend or
+          update it. However, you must take your own precautions to ensure that
+          the way you access this service does not expose you to the risk of
+          viruses, malicious computer code or other forms of interference which
+        may damage your own computer system.</p>
+        <p>You must not misuse our service by knowingly introducing viruses,
+          trojans, worms, logic bombs or other material which is malicious or
+          technologically harmful. You must not attempt to gain unauthorised
+          access to our service, the system on which our service is stored or any
+          server, computer or database connected to our service. You must not
+          attack our site via a denial-of-service attack or a distributed
+        denial-of-service attack.</p>
+        <h2 class="heading-large" id="privacy-policy">Privacy policy</h2>
+        <h3 class="heading-medium" id="information-provided-by-this-service">Information provided by this service</h3>
+        <p>We work hard to ensure that information within this prison visit request
+          service is accurate. However, we can’t guarantee the accuracy and
+        completeness of any information at all times.</p>
+        <p>While we make every effort to ensure this service is accessible at all
+        times, we are not liable if it is unavailable for any period of time.</p>
+        <h3 class="heading-medium" id="how-we-use-your-information">How we use your information</h3>
+        <p>The Ministry of Justice (HM Prison Service) uses and retains the
+          personal data of visitors for the purposes of the safe and secure
+          provision of Prison Services, including those related to the management
+        and rehabilitation of offenders.</p>
+        <p>Access to the establishment can only be granted by supplying the
+          prescribed information in order to ensure and maintain a safe and secure
+        environment for all.</p>
+        <p>You have the right to request details as to the personal information we
+          hold for you; and subsequently request that we correct any personal
+          information if it is found to be inaccurate or out of date. We will not
+          share your information with other organisations unless it is required
+          for the purposes of prevention, detection of crime, apprehension,
+          prosecution, and management of offenders; prevention of terrorism;
+        national security; or required to do by law.</p>
+        <p>Separately from the information entered by those using this service, we
+          also collect site-usage information which allows us to see how the
+          service is being used in order to allow us to improve it. This
+        information does not contain any personal data.</p>
+        <p>It includes:</p>
+        <ul class="list list-bullet">
+          <li>questions, queries or feedback you leave, including your email
+          address if you send a message via feedback</li>
+          <li>your IP address, and details of which version of web browser you
+          used</li>
+          <li>information on how you use the site, using cookies and page tagging
+          techniques to help us improve the website</li>
+        </ul>
+        <p>This helps us to:</p>
+        <ul class="list list-bullet">
+          <li>improve the site by monitoring how you use it</li>
+          <li>respond to any feedback you send us, if you’ve asked us to</li>
+          <li>provide you with information about local services if you want it</li>
+        </ul>
+        <p>We can’t personally identify you using your data.</p>
+        <h3 class="heading-medium" id="where-your-data-is-stored">Where your data is stored</h3>
+        <p>We store your data on our secure servers in the UK. However, it may also
+          be stored outside of Europe, where it could be viewed by our staff or
+        suppliers. By submitting your personal data, you agree to this.</p>
+        <p>We also use other suppliers to provide this service:</p>
+        <ul class="list list-bullet">
+          <li><a href="http://sendgrid.com">SendGrid</a> to relay information to prisons. See
+          the <a href="http://sendgrid.com/tos">terms &amp; conditions</a> attached to
+          this service.</li>
+          <li><a href="http://www.zendesk.com">ZenDesk</a> to handle any feedback that
+            you leave. See the <a href="http://www.zendesk.com/company/terms">terms &amp;
+            conditions</a> attached to
+          this service.</li>
+        </ul>
+        <h3 class="heading-medium" id="keeping-your-data-secure">Keeping your data secure</h3>
+        <p>Transmitting information over the internet is generally not completely
+          secure, and we can’t guarantee the security of your data. We do however
+          use SSL in order to encrypt all data transferred to and received from
+        our server.</p>
+        <p>We take data security very seriously and we take every step to ensure
+        that your data remains private and secure.</p>
+        <h3 class="heading-medium" id="any-data-you-transmit-is-at-your-own-risk">Any data you transmit is at your own risk.</h3>
+        <p>We have procedures and security features in place to try and keep your
+        data secure once we receive it.</p>
+        <p>We won’t share your information with any other organisations for
+          marketing, market research or commercial purposes, and we don’t pass on
+        your details to other websites.</p>
+        <h3 class="heading-medium" id="disclosing-your-information">Disclosing your information</h3>
+        <p>We may pass on your personal information if we have a legal obligation
+        to do so.</p>
+        <h3 class="heading-medium" id="how-we-manage-sessions">How we manage sessions</h3>
+        <p>This service can be used to make a prison visit request. Your session is
+          active for 20 minutes even if you close your browser, or navigate away
+          from this service. During this time, personal information about you may
+        be visible to anyone with access to your computer.</p>
+        <p>Your data is held in memory during the duration of the session; this is
+        cleared after 20 minutes of inactivity.</p>
+        <h3 class="heading-medium" id="data-protection-act-1998">Data Protection Act 1998</h3>
+        <p>This service complies with all principles of the DPA 1998.</p>
+        <p>Ministry of Justice (MoJ) is the ‘data controller’ for the purposes of
+          the Act. However, the information you enter into this service is not
+          automatically transmitted to the Ministry of Justice, but is stored in a
+        secure database. No personal data will be used in testing this service.</p>
+        <p>Our hosting provider, and MoJ staff responsible for supporting this
+          service, will have access to the server in which all personal
+          information entered into this service is momentarily stored. All staff
+        who have access to the secure data have MoJ security clearance.</p>
+        <p>Anyone who believes their personal data is kept within this service has
+          the right to submit a subject access request to the MoJ, who will give
+        details of the information stored on the server.</p>
+        <h3  class="heading-medium" id="disclaimer">Disclaimer</h3>
+        <p>We don’t accept liability for loss or damage incurred by users of this
+          service, whether direct, indirect or consequential, whether caused by
+          tort, breach of contract or otherwise. This includes loss of income or
+          revenue, business, profits or contracts, anticipated savings, data,
+          goodwill, tangible property or wasted time in connection with this
+          service or any websites linked to it and any materials posted on it.
+          This condition shall not prevent claims for loss of or damage to your
+          tangible property or any other claims for direct financial loss that are
+        not excluded by any of the categories set out above.</p>
+        <p>This does not affect our liability for death or personal injury arising
+          from our negligence, nor our liability for fraudulent misrepresentation
+          or misrepresentation as to a fundamental matter, nor any other liability
+        which cannot be excluded or limited under applicable law.</p>
+        <h3  class="heading-medium" id="contact-us">Contact us</h3>
+        <p>Ministry of Justice
+          Digital Services, 11.51
+          102 Petty France
+        London SW1H 9AJ United Kingdom</p>
     cookies:
       title: Cookies
       body_html: |


### PR DESCRIPTION
This will update the styling of the terms & conditions page to be inline with GOVUK. We cannot add class names to markdown so lets change to HTML

Trello card https://trello.com/c/AWu3pOXT/1284-update-public-cookie-tcs-styling