### PR TITLE
Update cookies

### DIFF
--- a/config/initializers/session_store.rb
+++ b/config/initializers/session_store.rb
@@ -1,6 +1,6 @@
 # Be sure to restart your server when you modify this file.
 #
-Rails.application.config.session_store :cookie_store, expire_after: 30.minutes,
+Rails.application.config.session_store :cookie_store, expire_after: 20.minutes,
                                                       key: '_pvb_public_session',
                                                       secure: Rails.env.production?,
                                                       httponly: true


### PR DESCRIPTION
As part of this Trello card (https://trello.com/c/A2gUGB0u/1369-cookies-tidyup)
we are changing the name of the session cookie and setting it to expire
after 20mins.  The T&Cs already had 20mins written in to them.