### PR TITLE
Prevent search engines indexing site

### DIFF
--- a/app/middleware/robots_tag.rb
+++ b/app/middleware/robots_tag.rb
@@ -1,0 +1,15 @@
+class RobotsTag
+  X_ROBOT_TAG_HEADER_VALUE = 'none'.freeze
+  X_ROBOT_TAG_HEADER = 'X-Robots-Tag'.freeze
+
+  def initialize(app)
+    @app = app
+  end
+
+  def call(env)
+    status, headers, response = @app.call(env.dup)
+    headers[X_ROBOT_TAG_HEADER] = X_ROBOT_TAG_HEADER_VALUE
+
+    [status, headers, response]
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,6 +5,7 @@ require 'active_model/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'sprockets/railtie'
+require_relative '../app/middleware/robots_tag'
 require_relative '../app/middleware/http_method_not_allowed'
 
 Bundler.require(*Rails.groups)
@@ -64,5 +65,6 @@ module PrisonVisits
     config.max_threads = ENV.fetch('RAILS_MAX_THREADS', 15)
 
     config.middleware.insert_before Rack::Head, HttpMethodNotAllowed
+    config.middleware.use RobotsTag
   end
 end

--- a/spec/requests/robots_tag_spec.rb
+++ b/spec/requests/robots_tag_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe RobotsTag do
+  it "blocks all crawlers" do
+    get '/'
+    expect(response.headers["X-Robots-Tag"]).to eq "none"
+  end
+end


### PR DESCRIPTION
The service manual says that all services must tell search engines not
to index pages on their domain so that users start from GOV.UK rather
going directly to the service domain.  We have not been doing this and so
the public service shows up in Google results.  This PR implements the
X-Robots-Tag header, which applies to all content types in the app (e.g.
images, scripts, styles), not only HTML files.

Related to this Trello card:
https://trello.com/c/uTzGYsBk/15-prevent-search-engines-indexing-the-public-site