### PR TITLE
Refactor x-robots-tag

### DIFF
--- a/app/middleware/robots_tag.rb
+++ b/app/middleware/robots_tag.rb
@@ -7,7 +7,7 @@ class RobotsTag
   end
 
   def call(env)
-    status, headers, response = @app.call(env.dup)
+    status, headers, response = @app.call(env)
     headers[X_ROBOT_TAG_HEADER] = X_ROBOT_TAG_HEADER_VALUE
 
     [status, headers, response]

--- a/config/application.rb
+++ b/config/application.rb
@@ -5,7 +5,6 @@ require 'active_model/railtie'
 require 'action_controller/railtie'
 require 'action_view/railtie'
 require 'sprockets/railtie'
-require_relative '../app/middleware/robots_tag'
 require_relative '../app/middleware/http_method_not_allowed'
 
 Bundler.require(*Rails.groups)
@@ -65,6 +64,5 @@ module PrisonVisits
     config.max_threads = ENV.fetch('RAILS_MAX_THREADS', 15)
 
     config.middleware.insert_before Rack::Head, HttpMethodNotAllowed
-    config.middleware.use RobotsTag
   end
 end

--- a/config/initializers/robots_blocker.rb
+++ b/config/initializers/robots_blocker.rb
@@ -1,0 +1,3 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.use RobotsTag


### PR DESCRIPTION
We are implementing the x-robots-tag header across our repos and want to
have a consistent approach; therefore this will now be in an initializer

We have also decided to remove the '#dup' as do not feel it necessary.