### PR TITLE
Email confirmation

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -84,6 +84,7 @@ private
   def permitted_visitors_params
     [
       :email_address,
+      :email_address_confirmation,
       :phone_no,
       :additional_visitor_count,
       visitors_attributes: [

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -15,7 +15,8 @@ class VisitorsStep
 
   delegate :max_visitors, :adult_age, to: :visitor_constraints
 
-  validates :email_address, presence: true
+  validates :email_address, confirmation: true, presence: true
+  validates :email_address_confirmation, presence: true
   validates :phone_no, phone: true
 
   validate :validate_email, :validate_visitors

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -9,6 +9,7 @@ class VisitorsStep
   attribute :processor, :steps_processor
 
   attribute :email_address, :string
+  attribute :email_address_confirmation, :string
   attribute :phone_no, :string
   attribute :visitors, :visitor_list, default: [].freeze
   attribute :additional_visitor_count, :integer
@@ -16,7 +17,6 @@ class VisitorsStep
   delegate :max_visitors, :adult_age, to: :visitor_constraints
 
   validates :email_address, confirmation: true, presence: true
-  validates :email_address_confirmation, presence: true
   validates :phone_no, phone: true
 
   validate :validate_email, :validate_visitors
@@ -25,6 +25,10 @@ class VisitorsStep
 
   def email_address=(val)
     super(val.strip)
+  end
+
+  def email_address_confirmation=(val)
+    super(val.strip) if val
   end
 
   # Return at least Prison::MAX_VISITORS visitors, filling with new instances

--- a/app/views/booking_requests/_hidden_visitors_step.html.erb
+++ b/app/views/booking_requests/_hidden_visitors_step.html.erb
@@ -2,6 +2,8 @@
 
 <%= hidden_field_tag('visitors_step[email_address]',
                      visitors_step.email_address) %>
+<%= hidden_field_tag('visitors_step[email_address_confirmation]',
+                     visitors_step.email_address_confirmation) %>
 <%= hidden_field_tag('visitors_step[phone_no]',
                      visitors_step.phone_no) %>
 

--- a/app/views/booking_requests/_principal_visitor.html.erb
+++ b/app/views/booking_requests/_principal_visitor.html.erb
@@ -10,6 +10,8 @@
 
     <%= single_field(f, :email_address, :text_field, class: 'form-control') %>
 
+    <%= single_field(f, :email_address_confirmation, :text_field, class: 'form-control') %>
+
     <%= single_field(f, :phone_no, :text_field, class: 'form-control') %>
   </div>
 <% end %>

--- a/config/locales/en/errors.yml
+++ b/config/locales/en/errors.yml
@@ -9,7 +9,7 @@ en:
       models:
         prisoner_step:
           attributes:
-            first_name: 
+            first_name:
               blank: Enter a first name
             last_name:
               blank: Enter a last name
@@ -20,8 +20,11 @@ en:
           api:
             prisoner_does_not_exist: No prisoner matches the details you’ve supplied, please ask the prisoner to check your details are correct
         visitors_step:
+          confirmation: Make sure email addresses match
           attributes:
             email_address:
+              blank: Enter a valid email address
+            email_address_confirmation:
               blank: Enter a valid email address
             phone_no:
               invalid: Enter a valid phone number
@@ -38,7 +41,7 @@ en:
             first_name:
               blank: Enter a first name
             last_name:
-              blank: Enter a last name 
+              blank: Enter a last name
             date_of_birth:
               blank: Enter a date of birth
               inclusion: Enter a date of birth

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -94,6 +94,7 @@ en:
       date_of_birth_hint: You must be over 18 to book a visit
       email_address: Email address
       email_address_hint: We'll send email confirmation to this address
+      email_address_confirmation: Confirm email address
       phone_no: Phone number
     additional_visitors:
       visitor: "Visitor %{n}"

--- a/spec/controllers/booking_requests_controller_spec.rb
+++ b/spec/controllers/booking_requests_controller_spec.rb
@@ -18,6 +18,7 @@ RSpec.describe BookingRequestsController do
   let(:visitors_details) {
     {
       email_address: 'ada@test.example.com',
+      email_address_confirmation: 'ada@test.example.com',
       phone_no: '07900112233',
       visitors_attributes: {
         0 => {

--- a/spec/features/request_a_visit_spec.rb
+++ b/spec/features/request_a_visit_spec.rb
@@ -38,7 +38,11 @@ RSpec.feature 'Booking a visit', js: true do
     select_first_available_slot
     click_button 'Continue'
 
-    enter_visitor_information email_address: visitor_email
+    enter_visitor_information(
+      email_address: visitor_email,
+      email_address_confirmation: visitor_email
+    )
+
     click_button 'Add another visitor'
     enter_visitor_information index: 1
     click_button 'Continue'
@@ -73,7 +77,10 @@ RSpec.feature 'Booking a visit', js: true do
     select_first_available_slot
     click_button 'Continue'
 
-    enter_visitor_information email_address: visitor_email
+    enter_visitor_information(
+      email_address: visitor_email,
+      email_address_confirmation: visitor_email
+    )
     click_button 'Add another visitor'
     enter_visitor_information index: 1
     click_button 'Continue'
@@ -112,7 +119,10 @@ RSpec.feature 'Booking a visit', js: true do
     select_first_available_slot
     click_button 'Continue'
 
-    enter_visitor_information email_address: visitor_email
+    enter_visitor_information(
+      email_address: visitor_email,
+      email_address_confirmation: visitor_email
+    )
     click_button 'Add another visitor'
     enter_visitor_information index: 1
     click_button 'Continue'

--- a/spec/models/visitors_step_spec.rb
+++ b/spec/models/visitors_step_spec.rb
@@ -76,6 +76,13 @@ RSpec.describe VisitorsStep do
     end
   end
 
+  describe "email_address_confirmation=" do
+    it 'strips whitespace' do
+      subject.email_address_confirmation = ' email@example.com '
+      expect(subject.email_address_confirmation).to eq('email@example.com')
+    end
+  end
+
   describe 'backfilled_visitors' do
     it 'includes supplied visitors' do
       subject.visitors_attributes = {
@@ -162,6 +169,7 @@ RSpec.describe VisitorsStep do
   describe 'valid?' do
     before do
       subject.email_address = 'user@test.example.com'
+      subject.email_address_confirmation = 'user@test.example.com'
       subject.phone_no = '07900112233'
     end
 
@@ -225,6 +233,13 @@ RSpec.describe VisitorsStep do
       expect(subject).to_not be_valid
       expect(subject.errors[:phone_no]).to_not be_empty
     end
+
+    it 'is invalid if email_address confirmation does not match email address' do
+      subject.email_address_confirmation = 'blah@thing.com'
+      subject.email_address_confirmation = 'blahblah@thing.com'
+      expect(subject).to_not be_valid
+      expect(subject.errors[:email_address_confirmation]).to_not be_empty
+    end
   end
 
   context 'with age-related validations' do
@@ -234,6 +249,7 @@ RSpec.describe VisitorsStep do
 
     before do
       subject.email_address = 'user@test.example.com'
+      subject.email_address_confirmation = 'user@test.example.com'
       subject.phone_no = '07900112233'
     end
 

--- a/spec/support/helpers/features_helper.rb
+++ b/spec/support/helpers/features_helper.rb
@@ -17,16 +17,17 @@ module FeaturesHelper
     select_prison options.fetch(:prison_name)
   end
 
-  def enter_visitor_information(options = {})
+  def enter_visitor_information(new_options = {})
     options = {
       first_name: 'Ada',
       last_name: 'Lovelace',
       date_of_birth: Date.new(1970, 11, 30),
       prison_name: 'Reading Gaol',
       email_address: 'user@test.example.com',
+      email_address_confirmation: 'user@test.example.com',
       phone_no: '07771232323',
       index: 0
-    }.merge(options)
+    }.merge(new_options)
 
     index = options.fetch(:index)
 
@@ -36,6 +37,7 @@ module FeaturesHelper
 
       if index.zero?
         fill_in 'Email address', with: options.fetch(:email_address)
+        fill_in 'Confirm email address', with: options.fetch(:email_address_confirmation)
         fill_in 'Phone number', with: options.fetch(:phone_no)
       end
 


### PR DESCRIPTION
Double email entry will reduce the number of incorrect email addresses submitted and increase the number of confirmation/rejection emails received by visitors