### PR TITLE
Add intro copy to check your answers page

### DIFF
--- a/app/views/booking_requests/confirmation_step.html.erb
+++ b/app/views/booking_requests/confirmation_step.html.erb
@@ -9,6 +9,12 @@
   confirmation_step = @steps.fetch(:confirmation_step)
 %>
 
+<div class="grid-row">
+  <div class="column-full">
+    <p><%= t('.check_your_answers_intro_html') %></p>
+  </div>
+</div>
+
 <table class="responsive check-your-answers">
   <thead>
     <tr>

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -149,6 +149,9 @@ en:
         Our calendars are updated daily, so please try again later.
     confirmation_step:
       title: Check your visit details
+      check_your_answers_intro_html: >-
+        Check your visit details carefully and change anything you need to. <br>
+        You won’t be able to make changes to your visit after you have sent your request.
       prisoner_details: Prisoner details
       prisoner_name: Prisoner name
       date_of_birth: "Date of birth"


### PR DESCRIPTION
Add content to 'Check your visit details' screen to explain to visitors that they can't make changes to their visit after it has been requested. 