### PR TITLE
Fix ruby upgrade to v2.5.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -349,7 +349,7 @@ DEPENDENCIES
   webmock
 
 RUBY VERSION
-   ruby 2.5.1p57
+   ruby 2.5.3p105
 
 BUNDLED WITH
-   1.16.1
+   1.17.1


### PR DESCRIPTION
- Gemfile.lock now has correct ruby version
- This fixes the Heroku deploy issue