### PR TITLE
Update app name in 'build docker' step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -69,7 +69,7 @@ references:
           --build-arg COMMIT_ID=${CIRCLE_SHA1} \
           --build-arg BUILD_DATE=${BUILD_DATE} \
           --build-arg BUILD_TAG=${CIRCLE_BRANCH} \
-          -f Dockerfile.kubernetes -t pvb-public  .
+          -f Dockerfile.kubernetes -t app  .
 
   push_docker_image: &push_docker_image
     run:


### PR DESCRIPTION
When adding the 'build docker image' step in the CircleCi config I
incorrectly '-t pvb-public .', it's actually just looking for '-t app
.'.  The correct docker image/tag combo isn't able to be found and
therefore the workflow fails when trying to push the docker image.