### PR TITLE
Update Prometheus config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -226,6 +226,8 @@ jobs:
             -f ./deploy/staging/deployment.yaml\
             -f ./deploy/staging/ingress.yaml \
             -f ./deploy/staging/service.yaml \
+            -f ./deploy/staging/service-monitor.yaml \
+            -f ./deploy/staging/network-policy.yaml \
             -f ./deploy/staging/prison-visits-public-secrets.yaml \
         environment:
           <<: *github_team_name_slug

--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 GA_TRACKING_ID=your-ga-tracking-id
 SENTRY_JS_DSN=https://foo123@sentry.service.dsd.io/99
+PROMETHEUS_METRICS="string"

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 GA_TRACKING_ID=your-ga-tracking-id
 SENTRY_JS_DSN=https://foo123@sentry.service.dsd.io/99
-PROMETHEUS_METRICS=bool
+KUBERNETES_DEPLOYMENT=bool

--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,3 @@
 GA_TRACKING_ID=your-ga-tracking-id
 SENTRY_JS_DSN=https://foo123@sentry.service.dsd.io/99
-PROMETHEUS_METRICS="string"
+PROMETHEUS_METRICS=bool

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,7 +33,7 @@ module PrisonVisits
     config.ga_id = ENV['GA_TRACKING_ID']
     config.sentry_dsn = ENV['SENTRY_DSN']
     config.sentry_js_dsn = ENV['SENTRY_JS_DSN']
-    config.prometheus_metrics = ENV['PROMETHEUS_METRICS']
+    config.kubernetes_deployment = ENV['KUBERNETES_DEPLOYMENT']
 
     config.smoke_test =
       OpenStruct.new(

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -29,6 +29,8 @@ Rails.application.configure do
   config.action_controller.default_url_options = { host: service_url.hostname }
   # config.action_controller.asset_host = service_url.hostname
 
+  config.kubernetes_deployment = ENV['KUBERNETES_DEPLOYMENT']
+
   EmailAddressValidation.configure do |config|
     config.mx_checker = MxChecker.new
   end

--- a/config/initializers/prometheus_metrics.rb
+++ b/config/initializers/prometheus_metrics.rb
@@ -1,4 +1,4 @@
-if Rails.configuration.prometheus_metrics == 'on'
+if Rails.env.production? && Rails.configuration.kubernetes_deployment
   require 'prometheus_exporter/instrumentation'
   require 'prometheus_exporter/middleware'
 

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -29,18 +29,18 @@ spec:
         command: ['sh', '-c', "bundle exec puma -p 3000 -C ./config/puma_prod.rb --pidfile /tmp/server.pid"]
         ports:
         - containerPort: 3000
-#        livenessProbe:
-#          httpGet:
-#            path: /healthcheck
-#            port: 3000
-#          initialDelaySeconds: 10
-#          periodSeconds: 60
-#        readinessProbe:
-#          httpGet:
-#            path: /healthcheck
-#            port: 3000
-#          initialDelaySeconds: 10
-#          periodSeconds: 60
+        livenessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 60
+        readinessProbe:
+          httpGet:
+            path: /healthcheck
+            port: 3000
+          initialDelaySeconds: 10
+          periodSeconds: 60
         env:
         - name: SECRET_KEY_BASE
           valueFrom:
@@ -52,7 +52,7 @@ spec:
         - name: RAILS_SERVE_STATIC_FILES
           value: "true"
         - name: PROMETHEUS_METRICS
-          value: "on"
+          value: "true"
         - name:  PRISON_VISITS_API
           value: "https://prison-visits-booking-staff-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io/"
         - name: EMAIL_DOMAIN

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -51,7 +51,7 @@ spec:
           value: "production"
         - name: RAILS_SERVE_STATIC_FILES
           value: "true"
-        - name: PROMETHEUS_METRICS
+        - name: KUBERNETES_DEPLOYMENT
           value: "true"
         - name:  PRISON_VISITS_API
           value: "https://prison-visits-booking-staff-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io/"

--- a/deploy/staging/network-policy.yaml
+++ b/deploy/staging/network-policy.yaml
@@ -1,0 +1,16 @@
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-prometheus-scraping
+  namespace: prison-visits-booking-staging
+spec:
+  podSelector:
+    matchLabels:
+      app: prison-visits-public
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          component: monitoring

--- a/deploy/staging/service-monitor.yaml
+++ b/deploy/staging/service-monitor.yaml
@@ -1,0 +1,15 @@
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: prison-visits-public
+  namespace: prison-visits-booking-staging
+spec:
+  selector:
+    matchLabels:
+      app: prison-visits-public
+  namespaceSelector:
+    matchNames:
+    - prison-visits-booking-staging
+  endpoints:
+  - port: metrics
+    interval: 15s


### PR DESCRIPTION
This PR creates the necessary network-policy and service-monitor
files for Prometheus to be fully implemented.  The CircleCi config has
also been update to reference these new files so they are deployed too.

The .env.example file has also been updated to reference the
PROMETHEUS_METRICS env var required to switch Prometheus metrics export
on and off.