### PR TITLE
Update puma_prod

### DIFF
--- a/config/puma_prod.rb
+++ b/config/puma_prod.rb
@@ -2,9 +2,3 @@ workers 4
 thread_pool_size = ENV.fetch('RAILS_MAX_THREADS') { 5 }
 threads thread_pool_size, thread_pool_size
 preload_app!
-
-after_worker_boot do
-  require 'prometheus_exporter/instrumentation'
-  PrometheusExporter::Instrumentation::Puma.start
-  PrometheusExporter::Instrumentation::Process.start(type: 'web')
-end


### PR DESCRIPTION
PVB Public builds on Jenkins are failing and it appears to be linked to
an unnecessary set of commands related to  prometheus exporter.