### PR TITLE
Migrate PVB Public from Live-0 -> Live-1

### DIFF
--- a/Dockerfile.kubernetes
+++ b/Dockerfile.kubernetes
@@ -59,6 +59,13 @@ COPY Gemfile Gemfile.lock ./
 
 RUN bundle install --without development test --jobs 2 --retry 3
 COPY . /app
+
+RUN mkdir -p /home/appuser && \
+  useradd appuser -u 1001 --user-group --home /home/appuser && \
+  chown -R appuser:appuser /app && \
+  chown -R appuser:appuser /home/appuser
+
+USER 1001
+
 RUN RAILS_ENV=production STAFF_SERVICE_URL=http://example.com SERVICE_URL=http://example.com rails assets:precompile --trace
 EXPOSE 3000
-

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -24,7 +24,7 @@ spec:
     spec:
       containers:
       - name: prison-visits-public
-        image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/prison-visits-booking/prison-visits-public:latest
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-public:latest
         imagePullPolicy: Always
         command: ['sh', '-c', "bundle exec puma -p 3000 -C ./config/puma_prod.rb --pidfile /tmp/server.pid"]
         ports:
@@ -54,13 +54,13 @@ spec:
         - name: KUBERNETES_DEPLOYMENT
           value: "true"
         - name:  PRISON_VISITS_API
-          value: "https://prison-visits-booking-staff-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io/"
+          value: "https://prison-visits-booking-staff-staging.apps.live-1.cloud-platform.service.justice.gov.uk/"
         - name: EMAIL_DOMAIN
           value: "email-staging.pvb.dsd.io"
         - name: STAFF_SERVICE_URL
-          value: "https://prison-visits-booking-staff-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+          value: "https://prison-visits-booking-staff-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
         - name: SERVICE_URL
-          value: "https://prison-visits-public-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io"
+          value: "https://prison-visits-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk"
         - name: SENTRY_DSN
           valueFrom:
             secretKeyRef:
@@ -82,7 +82,7 @@ spec:
               name: prison-visits-public-secrets
               key: rails_web_concurrency
       - name: prison-visits-public-metrics
-        image: 926803513772.dkr.ecr.eu-west-1.amazonaws.com/prison-visits-booking/prison-visits-public:latest
+        image: 754256621582.dkr.ecr.eu-west-2.amazonaws.com/prison-visits-booking/prison-visits-public:latest
         imagePullPolicy: Always
         command: ['sh', '-c', "bundle exec prometheus_exporter"]
         ports:

--- a/deploy/staging/ingress.yaml
+++ b/deploy/staging/ingress.yaml
@@ -8,9 +8,9 @@ metadata:
 spec:
   tls:
   - hosts:
-    - prison-visits-public-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
+    - prison-visits-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
   rules:
-  - host: prison-visits-public-staging.apps.cloud-platform-live-0.k8s.integration.dsd.io
+  - host: prison-visits-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
     http:
       paths:
       - path: /

--- a/deploy/staging/network-policy.yaml
+++ b/deploy/staging/network-policy.yaml
@@ -1,7 +1,7 @@
 kind: NetworkPolicy
 apiVersion: networking.k8s.io/v1
 metadata:
-  name: allow-prometheus-scraping
+  name: allow-prometheus-scraping-pvb-public
   namespace: prison-visits-booking-staging
 spec:
   podSelector:


### PR DESCRIPTION
When we initially moved PVB Public staging onto Kubernetes we did so
using the original Cloud Platform Live-0 cluster.  However, they are now
using the Live-1 cluster and in preparation for our full PVB migration
from Template Deploy to Kubernetes we need to migrate our staging env to this new
cluster.