### PR TITLE
Replace sass with a supported gem (sassc)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,7 +25,7 @@ gem 'pvb-instrumentation',
     tag: 'v1.0.1'
 gem 'rake'
 gem 'request_store'
-gem 'sass-rails', require: false
+gem 'sassc-rails'
 gem 'sentry-raven', '~> 2.9.0'
 gem 'string_scrubber'
 gem 'uglifier', '~> 4.1.20', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -248,12 +248,15 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.0.7)
-      railties (>= 4.0.0, < 6)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sassc (2.0.1)
+      ffi (~> 1.9)
+      rake
+    sassc-rails (2.1.1)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     selenium-webdriver (3.142.0)
       childprocess (>= 0.5, < 2.0)
       rubyzip (~> 1.2, >= 1.2.2)
@@ -338,7 +341,7 @@ DEPENDENCIES
   rubocop
   rubocop-performance
   rubocop-rspec
-  sass-rails
+  sassc-rails
   selenium-webdriver
   sentry-raven (~> 2.9.0)
   shoulda-matchers


### PR DESCRIPTION
As sass is out of support now (since end March 2019), this PR
switches to using sassc via rails-sassc.