### PR TITLE
Remove test staging step in deployment pipeline

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,34 +88,6 @@ references:
         <<: *github_team_name_slug
         REPONAME: prison-visits-public
 
-  restore_cache: &restore_cache
-    restore_cache:
-      keys:
-        - integration-tests-v2-{{ checksum "Gemfile.lock" }}
-        - integration-tests-v2-
-
-  install_gems: &install_gems
-    run:
-      name: Clone and install gems
-      command: |
-        git clone git@github.com:ministryofjustice/prison-visits-integration-tests.git
-        cd prison-visits-integration-tests
-        bundle check --path vendor/bundle || bundle install --path vendor/bundle
-
-  save_cache: &save_cache
-    save_cache:
-      key: integration-tests-v2-{{ checksum "Gemfile.lock" }}
-      paths:
-        - ~/staging/vendor/bundle
-
-  store_test_results: &store_test_results
-    store_test_results:
-      path: ./prison-visits-integration-tests/screenshots
-
-  store_artifacts: &store_artifacts
-    store_artifacts:
-      path: ./prison-visits-integration-tests/screenshots
-
 version: 2
 jobs:
   install_dependencies:
@@ -254,24 +226,6 @@ jobs:
         environment:
           <<: *github_team_name_slug
 
-  test_staging:
-    <<: *test_container_config
-    working_directory: ~/staging
-    steps:
-      - checkout
-      - *restore_cache
-      - *install_gems
-      - *save_cache
-      - run:
-          name: run integration tests
-          command: |
-            cd prison-visits-integration-tests
-            VCR=1 bundle exec rspec spec/integration --no-color --format documentation --format RspecJunitFormatter -o screenshots/rspec.xml
-          environment:
-            STAGING_START_PAGE: https://prison-visits-public-staging.apps.live-1.cloud-platform.service.justice.gov.uk
-      - *store_test_results
-      - *store_artifacts
-
   deploy_production:
     <<: *deploy_container_config
     steps:
@@ -324,17 +278,10 @@ workflows:
         filters:
           branches:
             only: master
-    - test_staging:
-          requires:
-            - build_and_push_docker_image
-            - deploy_staging
-          filters:
-            branches:
-              only: master
     - deploy_production_approval:
         type: approval
         requires:
-          - test_staging
+          - deploy_staging
         filters:
           branches:
             only: master


### PR DESCRIPTION
Whilst preparing for the migration of PVB from template deploy to
kubernetes we planned to have a step in the deployment pipeline that
would run the integration tests against staging, once deployed, so we
could check that nothing had broken before deploying to production.
However, as PVB staff is whitelisted we have run into issues where
Circle is unable to access the site to complete the tasks within the
integration tests.  We discussed this as a team and have come to the
agreement that we will remove this step and run it manually from our own
machines, that will have access.  This is not an ideal solution, but we
do not have the capacity within the team at present to explore the
possibility of switching staging to point at T3 rather than pre-prod.
If we could achieve this in the future we would then be able to remove
the whitelisting restrictions against staging and add this step back
into the deployment pipeline.