### PR TITLE
Add flash notice re: service migration

### DIFF
--- a/app/controllers/booking_requests_controller.rb
+++ b/app/controllers/booking_requests_controller.rb
@@ -8,7 +8,11 @@ class BookingRequestsController < ApplicationController
     instrument_booking_request(step_name: @step_name)
 
     respond_to do |format|
-      format.html { render processor.step_name }
+      format.html do render processor.step_name end
+
+      # Temporarily display flash notice ahead of PVB migration 25/7/19;
+      # it will be removed once the migration complete
+      flash[:notice] = t('.service_update')
     end
   end
 

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -12,6 +12,8 @@ en:
           <span>This service is being improved and you may notice changes – <a href='%{url}' target='_blank' rel='external'>contact us<span class='visuallyhidden'> (link opens in a new browser window)</span></a> if you need help.</span>
         </p>
   booking_requests:
+    index:
+      service_update: This service will be unavailable from 10am - 2pm Thursday 25th July 2019
     hidden_inputs_for_calendars:
       option_0: Option 1
       option_1: Option 2

--- a/spec/controllers/booking_requests_controller_spec.rb
+++ b/spec/controllers/booking_requests_controller_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe BookingRequestsController do
 
       it 'renders the prisoner template' do
         expect(response).to render_template('prisoner_step')
+        expect(request.flash[:notice]).to eq "This service will be unavailable from 10am - 2pm Thursday 25th July 2019"
       end
     end
 


### PR DESCRIPTION
We are due to migrate PVB from template deploy to kubernetes by the end
of the week. Our intention is to create a maintenance page, but we would
like to forewarn the public by displaying a flash notice for the next
couple of days.  This flash notice is displayed on the 'Who are you
visiting' & 'When would you like to visit' pages only.

This flash alert PR will need to be reverted as part of the migration
tasks to ensure the public do not see it once the work has been completed.

<img width="1114" alt="Screen Shot 2019-07-22 at 12 21 39" src="https://user-images.githubusercontent.com/20423761/61630113-cc99d080-ac7e-11e9-9064-a43b88819c40.png">
