### PR TITLE
Move require statement to correct file

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,5 @@
 require File.expand_path('../config/application', __FILE__)
+require 'turnout/rake_tasks'
 
 Rails.application.load_tasks
 task :default do

--- a/bin/rake
+++ b/bin/rake
@@ -1,5 +1,4 @@
 #!/usr/bin/env ruby
 require_relative '../config/boot'
-require 'turnout/rake_tasks'
 require 'rake'
 Rake.application.run


### PR DESCRIPTION
I misread the Turnout docs and added the "require 'turnout/rake_tasks'" to the wrong file, this PR fixes that issue.