### PR TITLE
Use /ping endpoint for liveness check

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -31,13 +31,13 @@ spec:
         - containerPort: 3000
         livenessProbe:
           httpGet:
-            path: /healthcheck
+            path: /ping
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 60
         readinessProbe:
           httpGet:
-            path: /healthcheck
+            path: /ping
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 60

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -31,13 +31,13 @@ spec:
         - containerPort: 3000
         livenessProbe:
           httpGet:
-            path: /healthcheck
+            path: /ping
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 60
         readinessProbe:
           httpGet:
-            path: /healthcheck
+            path: /ping
             port: 3000
           initialDelaySeconds: 10
           periodSeconds: 60


### PR DESCRIPTION
The livenessProbe from K8S hits the healthcheck endpoint quite a lot,
which in turn hits the staff service.  As k8s just wants to know the app
is up and responding, we will instead ask it to use the ping endpoint.