### PR TITLE
Add redirect for well-known security URL

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   end
 
   get '/', to: redirect(ENV.fetch('GOVUK_START_PAGE', '/en/request'))
+  get '/.well_known/security.txt', to: redirect('https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt')
 
   match 'exception', to: 'errors#test', via: %i[ get post ]
 

--- a/spec/routing/standards_redirect_spec.rb
+++ b/spec/routing/standards_redirect_spec.rb
@@ -7,4 +7,11 @@ RSpec.describe 'redirects paths to meet standards', type: :request do
     expect(response).
       to redirect_to('/en/request')
   end
+
+  # Following https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt/
+  it 'redirects well-known security URL to MOJ\'s disclosure policy' do
+    get '/.well_known/security.txt'
+    expect(response).
+      to redirect_to('https://raw.githubusercontent.com/ministryofjustice/security-guidance/master/contact/vulnerability-disclosure-security.txt')
+  end
 end

--- a/spec/routing/standards_redirect_spec.rb
+++ b/spec/routing/standards_redirect_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe 'redirects paths to meet standards', type: :request do
+  # Following https://www.gov.uk/service-manual/technology/get-a-domain-name#ensure-users-start-their-journey-on-govuk
+  it 'redirects the homepage' do
+    get '/'
+    expect(response).
+      to redirect_to('/en/request')
+  end
+end


### PR DESCRIPTION
[MOJ's security guidance](https://ministryofjustice.github.io/security-guidance/contact/implement-security-txt) says "Domains where the MOJ is primarily responsible for cyber security must redirect the `/.well_known/security.txt` location to the central `security.txt` file", which is hosted on GitHub.

[PVB's public domain](https://www.prisonvisits.service.gov.uk/.well_known/security.txt) is used as the example in the guidance, so let's get that one set up at least :)

Also add a test for the homepage redirect. That one isn't testing the redirect location which is set with the `GOVUK_START_PAGE` envvar, mainly because the way I've found in this repo of setting envvars in tests [(using `let`)](https://github.com/ministryofjustice/prison-visits-public/blob/355ed7b6d5cf790da2593e812d29bcef560e0f49/spec/middleware/http_method_not_allowed_spec.rb#L5) doesn't seem to work in this context - I assume because it's an envvar used in `routes.rb`. Suggestions of alternative approaches welcome :)