### PR TITLE
Make pods safely moveable

### DIFF
--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -7,13 +7,14 @@ metadata:
   annotations:
     kubernetes.io/change-cause: "<to be filled in deploy job command>"
 spec:
-  replicas: 3
+  replicas: 4
   revisionHistoryLimit: 1
   minReadySeconds: 10
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 2
+      maxSurge: 100%
+      maxUnavailable: 50%
+    type: RollingUpdate
   selector:
     matchLabels:
       app: prison-visits-public

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -7,13 +7,14 @@ metadata:
   annotations:
     kubernetes.io/change-cause: "<to be filled in deploy job command>"
 spec:
-  replicas: 3
+  replicas: 4
   revisionHistoryLimit: 1
   minReadySeconds: 10
   strategy:
     rollingUpdate:
-      maxSurge: 1
-      maxUnavailable: 2
+      maxSurge: 100%
+      maxUnavailable: 50%
+    type: RollingUpdate
   selector:
     matchLabels:
       app: prison-visits-public


### PR DESCRIPTION
Cloudplatform are making changes to ensure that pods don't get too old,
and to do this they will be randomly killing older pods from time to
time (and/or migrating them to other nodes).

This PR makes the recommended changes to ensure the system can safely
stay up and running during this process.

The number of pods is also increased (inline with the recommendation)
and so it is probably best to ensure the resources used by the new pod
are not excessive.