### PR TITLE
Fix the Welsh calendar journey

### DIFF
--- a/config/locales/cy/defaults.yml
+++ b/config/locales/cy/defaults.yml
@@ -15,53 +15,53 @@ cy:
       year_and_month_internal: '%Y-%m'
       date_internal: '%Y-%m-%d'
     day_names:
-    - Dydd Sul
-    - Dydd Llun
-    - Dydd Mawrth
-    - Dydd Mercher
-    - Dydd Iau
-    - Dydd Gwener
-    - Dydd Sadwrn
+      - Sul
+      - Llun
+      - Maw
+      - Mer
+      - Iau
+      - Gwe
+      - Sad
     abbr_day_names:
-    - Sul
-    - Llun
-    - Maw
-    - Mer
-    - Iau
-    - Gwe
-    - Sad
+      - Sul
+      - Llun
+      - Maw
+      - Mer
+      - Iau
+      - Gwe
+      - Sad
     month_names:
-    - Dim
-    - Ionawr
-    - Chwefror
-    - Mawrth
-    - Ebrill
-    - Mai
-    - 'Mehefin '
-    - Gorffennaf
-    - Awst
-    - Medi
-    - Hydref
-    - Tachwedd
-    - Rhagfyr
+      - Dim
+      - Ionawr
+      - Chwefror
+      - Mawrth
+      - Ebrill
+      - Mai
+      - Mehefin
+      - Gorffennaf
+      - Awst
+      - Medi
+      - Hydref
+      - Tachwedd
+      - Rhagfyr
     abbr_month_names:
-    - Dim
-    - Ion
-    - Chwe
-    - Maw
-    - Ebr
-    - Mai
-    - Meh
-    - Gorff
-    - Awst
-    - Medi
-    - Hyd
-    - Tach
-    - Rhag
+      - Dim
+      - Ion
+      - Chwe
+      - Maw
+      - Ebr
+      - Mai
+      - Meh
+      - Gorff
+      - Awst
+      - Medi
+      - Hyd
+      - Tach
+      - Rhag
     order:
-    - diwrnod
-    - mis
-    - blwyddyn
+      - diwrnod
+      - mis
+      - blwyddyn
   time:
     formats:
       twelve_hour: '%-l:%M%P'
@@ -71,15 +71,14 @@ cy:
     hour:
       one: awr
       other: awr
-      many: awr
-      two: awr
     minute:
       one: munud
       other: munud
-      many: munud
-      two: munud
   formats:
     slot:
+      first: first
+      second: second
+      third: third
       public:
         full: '%{date} %{time} am %{duration}'
         begin_only: '%{date} %{time}'
@@ -89,12 +88,8 @@ cy:
       hours:
         one: '%{count} awr'
         other: '%{count} awr'
-        many: '%{count} awr'
-        two: '%{count} awr'
       minutes:
         one: '%{count} munud'
         other: '%{count} munud'
-        many: '%{count} munud'
-        two: '%{count} munud'
     name:
       full: '%{first} %{last}'

--- a/config/locales/cy/errors.yml
+++ b/config/locales/cy/errors.yml
@@ -49,3 +49,12 @@ cy:
         nodi fel sbam. Edrychwch yn eich ffolder sbam hefyd
       bounced: 'mae angen edrych ar hyn oherwydd bod negeseuon wedi cael eu hanfon
         yn ôl yn y gorffennol '
+
+  age_validator:
+    errors:
+      invalid_date: yn ddyddiad annilys
+      range: rhaid bod llai na %{max} mlynedd yn ôl
+
+    prisoner_number_validator:
+      errors:
+        format: Rhowch rif carcharor. Dylai fod yn 7 nod gan ddechrau gyda llythyr.

--- a/config/locales/cy/views.yml
+++ b/config/locales/cy/views.yml
@@ -19,6 +19,8 @@ cy:
       go_to_previous_month: 'Mynd yn ôl i''r mis blaenorol '
       go_to_next_month: Mynd ymlaen i'r mis nesaf
       javascript_enabled: Rhaid i JavaScript fod wedi'i alluogi
+      day_available: Ymweliadau ar gael
+      day_unavailable: Dim ymweliadau ar gael
     booking_calendar_legend:
       visit_days: 'Diwrnodau y gellir ymweld '
       non_visit_days: Diwrnodau na ellir ymweld
@@ -136,6 +138,9 @@ cy:
 '
     confirmation_step:
       title: Gwiriwch fanylion eich ymweliad
+      check_your_answers_intro_html: >-
+        Gwiriwch fanylion eich ymweliad yn ofalus a newid unrhyw beth sydd ei angen arnoch chi. <br>
+        Ni fyddwch yn gallu gwneud newidiadau i'ch ymweliad ar ôl i chi anfon eich cais.
       prisoner_details: Manylion y carcharor
       prisoner_name: Enw'r carcharor
       date_of_birth: Dyddiad geni
@@ -155,6 +160,7 @@ cy:
       change_visit_details: Newid dyddiad ac amser eich ymweliad
       ts_and_cs: null
       next_step: Anfon cais i ymweld
+      add_another_choice: Ychwanegwch ddewis arall
     cancel:
       link_text: 'Canslo a dileu''r holl fanylion '
       confirmation: 'Ydych chi''n siŵr eich bod yn dymuno canslo''r cais hwn i ymweld?


### PR DESCRIPTION
Whilst working on another piece of work I discovered that the calendar /
slot picker step within the Welsh flow was broken due to an issue with
the formatting of the day in the yaml file.

In addition to this I have discovered a number of missing translations
that were also impacting the service and have added these.