### PR TITLE
Update content to ensure visitors know they're making a request

### DIFF
--- a/config/locales/cy/defaults.yml
+++ b/config/locales/cy/defaults.yml
@@ -15,53 +15,53 @@ cy:
       year_and_month_internal: '%Y-%m'
       date_internal: '%Y-%m-%d'
     day_names:
-    - Dydd Sul
-    - Dydd Llun
-    - Dydd Mawrth
-    - Dydd Mercher
-    - Dydd Iau
-    - Dydd Gwener
-    - Dydd Sadwrn
+      - Sul
+      - Llun
+      - Maw
+      - Mer
+      - Iau
+      - Gwe
+      - Sad
     abbr_day_names:
-    - Sul
-    - Llun
-    - Maw
-    - Mer
-    - Iau
-    - Gwe
-    - Sad
+      - Sul
+      - Llun
+      - Maw
+      - Mer
+      - Iau
+      - Gwe
+      - Sad
     month_names:
-    - Dim
-    - Ionawr
-    - Chwefror
-    - Mawrth
-    - Ebrill
-    - Mai
-    - 'Mehefin '
-    - Gorffennaf
-    - Awst
-    - Medi
-    - Hydref
-    - Tachwedd
-    - Rhagfyr
+      - Dim
+      - Ionawr
+      - Chwefror
+      - Mawrth
+      - Ebrill
+      - Mai
+      - Mehefin
+      - Gorffennaf
+      - Awst
+      - Medi
+      - Hydref
+      - Tachwedd
+      - Rhagfyr
     abbr_month_names:
-    - Dim
-    - Ion
-    - Chwe
-    - Maw
-    - Ebr
-    - Mai
-    - Meh
-    - Gorff
-    - Awst
-    - Medi
-    - Hyd
-    - Tach
-    - Rhag
+      - Dim
+      - Ion
+      - Chwe
+      - Maw
+      - Ebr
+      - Mai
+      - Meh
+      - Gorff
+      - Awst
+      - Medi
+      - Hyd
+      - Tach
+      - Rhag
     order:
-    - diwrnod
-    - mis
-    - blwyddyn
+      - diwrnod
+      - mis
+      - blwyddyn
   time:
     formats:
       twelve_hour: '%-l:%M%P'
@@ -71,15 +71,14 @@ cy:
     hour:
       one: awr
       other: awr
-      many: awr
-      two: awr
     minute:
       one: munud
       other: munud
-      many: munud
-      two: munud
   formats:
     slot:
+      first: first
+      second: second
+      third: third
       public:
         full: '%{date} %{time} am %{duration}'
         begin_only: '%{date} %{time}'
@@ -89,12 +88,8 @@ cy:
       hours:
         one: '%{count} awr'
         other: '%{count} awr'
-        many: '%{count} awr'
-        two: '%{count} awr'
       minutes:
         one: '%{count} munud'
         other: '%{count} munud'
-        many: '%{count} munud'
-        two: '%{count} munud'
     name:
       full: '%{first} %{last}'

--- a/config/locales/cy/errors.yml
+++ b/config/locales/cy/errors.yml
@@ -49,3 +49,12 @@ cy:
         nodi fel sbam. Edrychwch yn eich ffolder sbam hefyd
       bounced: 'mae angen edrych ar hyn oherwydd bod negeseuon wedi cael eu hanfon
         yn ôl yn y gorffennol '
+
+  age_validator:
+    errors:
+      invalid_date: yn ddyddiad annilys
+      range: rhaid bod llai na %{max} mlynedd yn ôl
+
+    prisoner_number_validator:
+      errors:
+        format: Rhowch rif carcharor. Dylai fod yn 7 nod gan ddechrau gyda llythyr.

--- a/config/locales/cy/views.yml
+++ b/config/locales/cy/views.yml
@@ -95,9 +95,10 @@ cy:
     slots_step:
       title: 'Pa bryd hoffech chi ymweld? '
       slot1_error: Rhaid i chi ddewis o leiaf un dyddiad ac amser ar gyfer eich ymweliad
-      info_html: <p>Dewiswch hyd at 3 dyddiad ac amser ar gyfer eich ymweliad. Os
-        nad yw eich dewis cyntaf ar gael, byddwn yn ceisio sicrhau un o'ch dewisiadau
-        eraill.</p>
+      info_html: >-
+        <p>Dewiswch hyd at 3 dyddiad ac amser. Bydd y carchar yn cadarnhau un o’ch dewisiadau.</p>
+        <p>Cychwynnwch gyda’r dyddiad a’r amser fyddai orau gennych.  Mae’r dyddiadau sydd ar
+        gael wedi eu hamlygu mewn span class=bold>print bras</span>.</p>
       keyboard_directions_html: "<ul class=\"visuallyhidden\">\n  <li>Pwyswch y botymau
         saeth i'r DDE ac i'r CHWITH i symud ar y rhes yn ôl diwrnod yr wythnos.</li>\n
         \ <li>Pwyswch y botymau HAFAN a DIWEDD i neidio i ddechrau neu ddiwedd y mis
@@ -137,7 +138,7 @@ cy:
 
 '
     confirmation_step:
-      title: Gwiriwch fanylion eich ymweliad
+      title: Gwiriwch fanylion eich cais am ymweliad
       check_your_answers_intro_html: >-
         Gwiriwch fanylion eich ymweliad yn ofalus a newid unrhyw beth sydd ei angen arnoch chi. <br>
         Ni fyddwch yn gallu gwneud newidiadau i'ch ymweliad ar ôl i chi anfon eich cais.

--- a/config/locales/cy/views.yml
+++ b/config/locales/cy/views.yml
@@ -19,6 +19,8 @@ cy:
       go_to_previous_month: 'Mynd yn ôl i''r mis blaenorol '
       go_to_next_month: Mynd ymlaen i'r mis nesaf
       javascript_enabled: Rhaid i JavaScript fod wedi'i alluogi
+      day_available: Ymweliadau ar gael
+      day_unavailable: Dim ymweliadau ar gael
     booking_calendar_legend:
       visit_days: 'Diwrnodau y gellir ymweld '
       non_visit_days: Diwrnodau na ellir ymweld
@@ -136,6 +138,9 @@ cy:
 '
     confirmation_step:
       title: Gwiriwch fanylion eich ymweliad
+      check_your_answers_intro_html: >-
+        Gwiriwch fanylion eich ymweliad yn ofalus a newid unrhyw beth sydd ei angen arnoch chi. <br>
+        Ni fyddwch yn gallu gwneud newidiadau i'ch ymweliad ar ôl i chi anfon eich cais.
       prisoner_details: Manylion y carcharor
       prisoner_name: Enw'r carcharor
       date_of_birth: Dyddiad geni
@@ -155,6 +160,7 @@ cy:
       change_visit_details: Newid dyddiad ac amser eich ymweliad
       ts_and_cs: null
       next_step: Anfon cais i ymweld
+      add_another_choice: Ychwanegwch ddewis arall
     cancel:
       link_text: 'Canslo a dileu''r holl fanylion '
       confirmation: 'Ydych chi''n siŵr eich bod yn dymuno canslo''r cais hwn i ymweld?

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -107,11 +107,8 @@ en:
       slot1_error: You must choose at least one date and time slot.
       prisoner_changed: As you've changed the prisoner details, you need to choose new visit slots.
       info_html: >-
-        <ul class="list list-number">
-          <li>Choose a date (available dates are in <span class="bold-small">bold</span>)</li>
-          <li>Choose a time</li>
-        </ul>
-        <p>You can choose up to 3 options. Start with your first choice.</p>
+        <p>Choose up to 3 possible dates and times. The prison will confirm one of your choices for the visit.</p>
+        <p>Start with your first choice of date and time.  Available dates are in <span class=bold>bold</span>.</p>
       keyboard_directions_html: |
         <ul>
           <li>Press the LEFT and RIGHT arrow keys to navigate the row by week day.</li>
@@ -148,7 +145,7 @@ en:
 
         Our calendars are updated daily, so please try again later.
     confirmation_step:
-      title: Check your visit details
+      title: Check your visit request details
       check_your_answers_intro_html: >-
         Check your visit details carefully and change anything you need to. <br>
         You won’t be able to make changes to your visit after you have sent your request.


### PR DESCRIPTION
We’ve had several requests for the service to clarify to users that they
are sending a request for a booking, and not a guarantee. Although the
email clarifies this it was agreed that we needed to update the content
on the site to be more explicit.  This PR updates the content in both
English and Welsh.