### PR TITLE
Redo google analytics

### DIFF
--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -5,8 +5,7 @@
   moj.Modules.AsyncGA = {
     el: '.js-AsyncGA',
     init: function() {
-      GOVUK.Analytics.load();
-      if($(this.el).length>0){
+      if ($(this.el).length > 0) {
         this.render();
       }
     },
@@ -14,27 +13,49 @@
     render: function() {
       // Use document.domain in dev, preview and staging so that tracking works
       // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
-      var cookieDomain = (document.domain === 'www.gov.uk') ? '.www.gov.uk' : document.domain;
+      var cookieDomain =
+        document.domain === 'www.gov.uk' ? '.www.gov.uk' : document.domain;
       var gaTrackingId = $(this.el).data('ga-tracking-id');
+
+      (function(i, s, o, g, r, a, m) {
+        i['GoogleAnalyticsObject'] = r;
+        (i[r] =
+          i[r] ||
+          function() {
+            (i[r].q = i[r].q || []).push(arguments);
+          }),
+          (i[r].l = 1 * new Date());
+        (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
+        a.async = 1;
+        a.src = g;
+        m.parentNode.insertBefore(a, m);
+      })(
+        window,
+        document,
+        'script',
+        'https://www.google-analytics.com/analytics.js',
+        'ga'
+      );
+
+      ga('create', gaTrackingId, cookieDomain);
 
       // Configure profiles and make interface public
       // for custom dimensions, virtual pageviews and events
-      GOVUK.analytics = new GOVUK.Analytics({
-        universalId: gaTrackingId,
-        cookieDomain: cookieDomain
-      });
 
-      this.hitTypePage  = $(this.el).eq(0).data('hit-type-page');
-      this.pageView = $(this.el).eq(0).data('page-view');
+      this.hitTypePage = $(this.el)
+        .eq(0)
+        .data('hit-type-page');
+      this.pageView = $(this.el)
+        .eq(0)
+        .data('page-view');
 
       if (this.hitTypePage) {
-        GOVUK.analytics.trackPageview(this.hitTypePage);
+        ga('send', 'pageview', this.hitTypePage);
       } else if (this.pageView) {
-        GOVUK.analytics.trackPageview(this.pageView);
+        ga('send', 'pageview', this.pageView);
       } else {
-        GOVUK.analytics.trackPageview();
+        ga('send', 'pageview');
       }
     }
   };
-
-}());
+})();

--- a/spec/javascripts/datepicker_spec.js
+++ b/spec/javascripts/datepicker_spec.js
@@ -9,6 +9,7 @@ describe('moj.Modules.Slotpicker', function() {
     datePicker = new moj.Modules.Slotpicker.Datepicker(calendar, calendar.data());
     moj.Modules.Slotpicker.Helpers.init();
     moj.Modules.Slotpicker.SlotSource.init();
+    moj.Modules.Analytics.send = function() {};
   });
 
   describe('fixture', function() {

--- a/spec/javascripts/fixtures/calendar.html
+++ b/spec/javascripts/fixtures/calendar.html
@@ -36,6 +36,7 @@
 <div id='slot_0'
      class='js-calendar calendar'
      data-target-id='dateValue'
+     data-available-message='Visits available'
      data-slot-source='slots_step_option_0'
      data-slot-list='js-slotAvailability'
      data-slot-target='js-slotTarget'


### PR DESCRIPTION
 Initially, pure GA (google analytics) was being implemented. This was later removed and replaced with a `gov.uk` module [https://docs.publishing.service.gov.uk/manual/analytics.html](url), which acted like a wrapper for GA. However, this now deprecated.  This PR strips the old implementation with the deprecated module, and implements pure GA.