### PR TITLE
Revert "Bump prometheus_exporter from 0.4.17 to 0.5.1"

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -162,7 +162,7 @@ GEM
       ast (~> 2.4.0)
     phantomjs (2.1.1.0)
     phonelib (0.6.42)
-    prometheus_exporter (0.5.1)
+    prometheus_exporter (0.4.17)
     pry (0.12.2)
       coderay (~> 1.1.0)
       method_source (~> 0.9.0)


### PR DESCRIPTION
Reverts ministryofjustice/prison-visits-public#896

For some reason when trying to bump the prometheus exporter on public it fails and causes pods to enter a crash loop backoff state.  I don't want to deploy this to prod so need to revert!