### PR TITLE
Gdpr compliant cookies

### DIFF
--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -1,43 +1,64 @@
 /*global ga */
 (function() {
-  'use strict';
+  "use strict";
 
   moj.Modules.AsyncGA = {
-    el: '.js-AsyncGA',
+    el: ".js-AsyncGA",
     init: function() {
       if ($(this.el).length > 0) {
-        this.render();
+        var gaTrackingId = $(this.el).data("ga-tracking-id");
+        this.render(gaTrackingId);
       }
     },
 
-    render: function() {
+    render: function(gaTrackingId) {
       var self = this;
-      window['ga-disable-UA-14565299-1'] = true;
+      window["ga-disable-UA-14565299-1"] = true;
+      if (window.location.href.includes("cookies")) {
+        document.getElementById("save_cookie_preference").onclick = function() {
+          if (document.getElementById("accept_cookies-yes").checked == true) {
+            self.hideCookieBanner();
+            document.cookie =
+              "accepted_cookies=true; expires=" +
+              self.cookieOneYearExpiration() +
+              ";";
+            window["ga-disable-UA-14565299-1"] = false;
 
+            self.trackPageView();
+          } else {
+            self.hideCookieBanner();
+            document.cookie =
+              "accepted_cookies=false; expires=" +
+              self.cookieOneYearExpiration() +
+              ";";
+            window["ga-disable-UA-14565299-1"] = true;
+            self.trackPageView();
+          }
+        };
+      }
       document.getElementById("accept-cookies").onclick = function() {
         self.hideCookieBanner();
         document.cookie =
-          'accepted_cookies=true; expires=' +
+          "accepted_cookies=true; expires=" +
           self.cookieOneYearExpiration() +
-          ';';
-        window['ga-disable-UA-14565299-1'] = false;
+          ";";
+        window["ga-disable-UA-14565299-1"] = false;
 
         self.trackPageView();
       };
-      document.getElementById('reject-cookies').onclick = function() {
+      document.getElementById("reject-cookies").onclick = function() {
         document.cookie =
-          'accepted_cookies=false; expires=' +
+          "accepted_cookies=false; expires=" +
           self.cookieOneYearExpiration() +
-          ';';
-          window['ga-disable-UA-14565299-1'] = true;
+          ";";
+        window["ga-disable-UA-14565299-1"] = true;
         self.hideCookieBanner();
       };
       var cookieDomain =
-        document.domain === 'www.gov.uk' ? '.www.gov.uk' : document.domain;
-      var gaTrackingId = $(this.el).data('ga-tracking-id');
+        document.domain === "www.gov.uk" ? ".www.gov.uk" : document.domain;
 
       (function(i, s, o, g, r, a, m) {
-        i['GoogleAnalyticsObject'] = r;
+        i["GoogleAnalyticsObject"] = r;
         (i[r] =
           i[r] ||
           function() {
@@ -51,53 +72,48 @@
       })(
         window,
         document,
-        'script',
-        'https://www.google-analytics.com/analytics.js',
-        'ga'
+        "script",
+        "https://www.google-analytics.com/analytics.js",
+        "ga"
       );
 
-      ga('create', gaTrackingId, cookieDomain);
+      ga("create", gaTrackingId, cookieDomain);
 
       // Configure profiles and make interface public
       // for custom dimensions, virtual pageviews and events
-      if (document.cookie.indexOf('accepted_cookies=true') > -1) {
+      if (document.cookie.indexOf("accepted_cookies=true") > -1) {
         this.hideCookieBanner();
-        window['ga-disable-UA-14565299-1'] = false;
+        window["ga-disable-UA-14565299-1"] = false;
         this.trackPageView();
       }
-      if (document.cookie.indexOf('accepted_cookies=false') > -1) {
+      if (document.cookie.indexOf("accepted_cookies=false") > -1) {
         this.hideCookieBanner();
-        window['ga-disable-UA-14565299-1'] = true;
+        window["ga-disable-UA-14565299-1"] = true;
       }
-
-      this.trackPageView();
     },
 
     trackPageView: function() {
       this.hitTypePage = $(this.el)
         .eq(0)
-        .data('hit-type-page');
+        .data("hit-type-page");
       this.pageView = $(this.el)
         .eq(0)
-        .data('page-view');
+        .data("page-view");
 
       if (this.hitTypePage) {
-        ga('send', 'pageview', this.hitTypePage);
+        ga("send", "pageview", this.hitTypePage);
       } else if (this.pageView) {
-        ga('send', 'pageview', this.pageView);
+        ga("send", "pageview", this.pageView);
       } else {
-        ga('send', 'pageview');
+        ga("send", "pageview");
       }
     },
     hideCookieBanner: function() {
-      document.getElementById('cookie-message').style.display = 'none';
-    },
-    removeCookie: function(name) {
-      document.cookie = name + '=; Max-Age=0';
+      document.getElementById("cookie-message").style.display = "none";
     },
     cookieOneYearExpiration: function() {
       var date = new Date();
-      date.setTime(+date + 365 * 86400000);
+      date.setFullYear(date.getFullYear() + 1);
       return date.toGMTString();
     }
   };

--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -11,8 +11,27 @@
     },
 
     render: function() {
-      // Use document.domain in dev, preview and staging so that tracking works
-      // Otherwise explicitly set the domain as www.gov.uk (and not gov.uk).
+      var self = this;
+      window['ga-disable-UA-14565299-1'] = true;
+
+      document.getElementById("accept-cookies").onclick = function() {
+        self.hideCookieBanner();
+        document.cookie =
+          'accepted_cookies=true; expires=' +
+          self.cookieOneYearExpiration() +
+          ';';
+        window['ga-disable-UA-14565299-1'] = false;
+
+        self.trackPageView();
+      };
+      document.getElementById('reject-cookies').onclick = function() {
+        document.cookie =
+          'accepted_cookies=false; expires=' +
+          self.cookieOneYearExpiration() +
+          ';';
+          window['ga-disable-UA-14565299-1'] = true;
+        self.hideCookieBanner();
+      };
       var cookieDomain =
         document.domain === 'www.gov.uk' ? '.www.gov.uk' : document.domain;
       var gaTrackingId = $(this.el).data('ga-tracking-id');
@@ -41,7 +60,20 @@
 
       // Configure profiles and make interface public
       // for custom dimensions, virtual pageviews and events
+      if (document.cookie.indexOf('accepted_cookies=true') > -1) {
+        this.hideCookieBanner();
+        window['ga-disable-UA-14565299-1'] = false;
+        this.trackPageView();
+      }
+      if (document.cookie.indexOf('accepted_cookies=false') > -1) {
+        this.hideCookieBanner();
+        window['ga-disable-UA-14565299-1'] = true;
+      }
 
+      this.trackPageView();
+    },
+
+    trackPageView: function() {
       this.hitTypePage = $(this.el)
         .eq(0)
         .data('hit-type-page');
@@ -56,6 +88,17 @@
       } else {
         ga('send', 'pageview');
       }
+    },
+    hideCookieBanner: function() {
+      document.getElementById('cookie-message').style.display = 'none';
+    },
+    removeCookie: function(name) {
+      document.cookie = name + '=; Max-Age=0';
+    },
+    cookieOneYearExpiration: function() {
+      var date = new Date();
+      date.setTime(+date + 365 * 86400000);
+      return date.toGMTString();
     }
   };
 })();

--- a/app/assets/javascripts/modules/moj.AsyncGA.js
+++ b/app/assets/javascripts/modules/moj.AsyncGA.js
@@ -17,42 +17,17 @@
       if (window.location.href.includes("cookies")) {
         document.getElementById("save_cookie_preference").onclick = function() {
           if (document.getElementById("accept_cookies-yes").checked == true) {
-            self.hideCookieBanner();
-            document.cookie =
-              "accepted_cookies=true; expires=" +
-              self.cookieOneYearExpiration() +
-              ";";
-            window["ga-disable-UA-14565299-1"] = false;
-
-            self.trackPageView();
+            self.acceptCookies();
           } else {
-            self.hideCookieBanner();
-            document.cookie =
-              "accepted_cookies=false; expires=" +
-              self.cookieOneYearExpiration() +
-              ";";
-            window["ga-disable-UA-14565299-1"] = true;
-            self.trackPageView();
+            self.rejectCookies();
           }
         };
       }
       document.getElementById("accept-cookies").onclick = function() {
-        self.hideCookieBanner();
-        document.cookie =
-          "accepted_cookies=true; expires=" +
-          self.cookieOneYearExpiration() +
-          ";";
-        window["ga-disable-UA-14565299-1"] = false;
-
-        self.trackPageView();
+        self.acceptCookies();
       };
       document.getElementById("reject-cookies").onclick = function() {
-        document.cookie =
-          "accepted_cookies=false; expires=" +
-          self.cookieOneYearExpiration() +
-          ";";
-        window["ga-disable-UA-14565299-1"] = true;
-        self.hideCookieBanner();
+        self.rejectCookies();
       };
       var cookieDomain =
         document.domain === "www.gov.uk" ? ".www.gov.uk" : document.domain;
@@ -93,6 +68,8 @@
     },
 
     trackPageView: function() {
+      window["ga-disable-UA-14565299-1"] = false;
+
       this.hitTypePage = $(this.el)
         .eq(0)
         .data("hit-type-page");
@@ -115,6 +92,16 @@
       var date = new Date();
       date.setFullYear(date.getFullYear() + 1);
       return date.toGMTString();
+    },
+    acceptCookies: function(){
+      this.hideCookieBanner();
+      document.cookie = "accepted_cookies=true; expires=" + this.cookieOneYearExpiration() + ";";
+      this.trackPageView();
+    },
+    rejectCookies: function(){
+      window["ga-disable-UA-14565299-1"] = true;
+      this.hideCookieBanner();
+      document.cookie = "accepted_cookies=false; expires=" + this.cookieOneYearExpiration() + ";";
     }
   };
 })();

--- a/app/assets/stylesheets/_buttons.scss
+++ b/app/assets/stylesheets/_buttons.scss
@@ -24,3 +24,7 @@
     background-color: $focus-colour;
   }
 }
+#save_cookie_preference {
+  margin-top: 20px;
+  margin-bottom: 30px;
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -50,3 +50,4 @@
 @import "modules/moj.booking-calendar";
 @import "responsive";
 @import "components/moj.autocomplete";
+@import "components/moj.cookie_banner";

--- a/app/assets/stylesheets/components/_moj.cookie_banner.scss
+++ b/app/assets/stylesheets/components/_moj.cookie_banner.scss
@@ -1,0 +1,3 @@
+.js-enabled #global-cookie-message {
+  display: none !important;
+}

--- a/app/assets/stylesheets/components/_moj.cookie_banner.scss
+++ b/app/assets/stylesheets/components/_moj.cookie_banner.scss
@@ -1,3 +1,62 @@
+.js-enabled #cookie-message {
+  display: block; /* shown with JS, always on for non-JS */
+}
 .js-enabled #global-cookie-message {
   display: none !important;
+}
+
+#cookie-message {
+  @extend %site-width-container;
+  @include core-19;
+
+  display: none;
+  padding: $gutter 0 (2 * $gutter);
+  color: $green;
+
+  .js-enabled & {
+    display: block;
+  }
+
+  form a.mtp-cancel-button {
+    color: $green;
+
+    &:visited {
+      color: darken($green, 10%);
+    }
+  }
+
+  .button {
+    border: 2px solid $green;
+    color: #fff;
+    background-color: $green;
+    box-shadow: none;
+
+    &:focus {
+      outline: none;
+      color: $text-colour;
+      background: $focus-colour;
+      border-color: $focus-colour;
+    }
+  }
+
+  @include media(mobile) {
+    .button {
+      width: 40%;
+    }
+
+    .mtp-cancel-button {
+      display: block;
+      margin-top: 1em;
+    }
+  }
+}
+
+#id_accept_cookies-wrapper {
+  margin-top: $gutter-half;
+}
+#accept-cookies {
+  margin-right: 10;
+}
+#reject-cookies {
+  margin-right: 10;
 }

--- a/app/assets/stylesheets/components/_moj.cookie_banner.scss
+++ b/app/assets/stylesheets/components/_moj.cookie_banner.scss
@@ -51,12 +51,9 @@
   }
 }
 
-#id_accept_cookies-wrapper {
-  margin-top: $gutter-half;
-}
 #accept-cookies {
-  margin-right: 10;
+  margin-right: 10px;
 }
 #reject-cookies {
-  margin-right: 10;
+  margin-right: 10px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -16,6 +16,18 @@
   <![endif]-->
 <% end %>
 
+<aside id="cookie-message">
+  <p>
+    <%= t('.cookies_intro_explanation') %>
+  </p>
+  <p>
+    <%= t('.cookies_question') %>
+  </p>
+    <button id="accept-cookies" class="button"><%= t('.accept_cookies')%></button>
+    <button id="reject-cookies" class="button"><%= t('.reject_cookies')%></button>
+    <a class="mtp-cancel-button" href="cookies"><%= t('.view_more_information')%></a>
+</aside>
+
 <% content_for :proposition_header do %>
   <div class="header-proposition">
     <div class="content">
@@ -40,13 +52,6 @@
 
 
 <% end %>
-
-<aside id="cookie-message">
-  <%= t('.cookies_intro_html') %>
-    <button id="accept-cookies" class="button"><%= t('.accept_cookies')%></button>
-    <button id="reject-cookies" class="button"><%= t('.reject_cookies')%></button>
-    <a class="mtp-cancel-button" href="cookies"><%= t('.view_more_information')%></a>
-</aside>
 
 <% content_for :content do %>
   <main id="content">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -41,10 +41,12 @@
 
 <% end %>
 
-<% content_for :cookie_message do %>
-  <%= t('.cookies_intro') %>
-  <%= link_to(t('.cookies_find_out_more'), cookies_path) %>
-<% end %>
+<aside id="cookie-message">
+  <%= t('.cookies_intro_html') %>
+    <button id="accept-cookies" class="button"><%= t('.accept_cookies')%></button>
+    <button id="reject-cookies" class="button"><%= t('.reject_cookies')%></button>
+    <a class="mtp-cancel-button" href="cookies"><%= t('.view_more_information')%></a>
+</aside>
 
 <% content_for :content do %>
   <main id="content">

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -229,6 +229,23 @@ cy:
         <p>Rydym yn defnyddio meddalwedd Google Analytics i gasglu gwybodaeth am sut yr ydych yn
         defnyddio PVB. Rydym yn gwneud hyn i helpu sicrhau bod y safle’n cwrdd ag anghenion
         ei defnyddwyr a’n helpu i wneud gwelliannau.</p>
+        <fieldset>
+        <legend> 
+          A ydych yn cytuno i’r Weinyddiaeth Gyfiawnder ac adrannau eraill o Lywodraeth y DU  i ddefnyddio Google Analytics i helpu wella’r ‘Gwasanaeth Ymweliadau Carchar’?
+        </legend>
+        <div id="id_accept_cookies-wrapper">
+          <div class="multiple-choice">
+            <input id="accept_cookies-yes" type="radio" name="accept_cookies" value="yes">
+            <label for="accept_cookies-yes" id="id_accept_cookies-label">Ydw</label>
+          </div>
+          <div class="multiple-choice">
+            <input id="accept_cookies-no" type="radio" name="accept_cookies" value="no">
+            <label for="accept_cookies-no" id="id_accept_cookies-label">Nac ydw</label>
+          </div>
+        </div>
+        </fieldset>
+        <input id="save_cookie_preference" class="button" type="submit" value= "Cadw newidiadau">
+        <p>Google Analytics stores information about:</p>
         <p>Mae Google Analytics yn storio gwybodaeth am:</p>
         <ul class="list list-bullet">
           <li>y tudalennau yr ydych wedi ymweld â nhw ar PVB - faint o amser yr ydych wedi’i dreulio ar bob tudalen PVB</li>
@@ -293,5 +310,10 @@ cy:
               <td aria-label="Pwrpas">Storio manylion carcharor, ymwelydd a manylion yr ymweliad</td>
               <td aria-label="Dod i ben">20 munud</td>
             </tr>
+          <tr>
+            <td aria-label="Name">accepted_cookies</td>
+            <td aria-label="Pwrpas">daves caniatâd cwci</td>
+            <td aria-label="Dod i ben">1 flwyddyn</td>
+          </tr>
           </tbody>
         </table>

--- a/config/locales/cy/views.yml
+++ b/config/locales/cy/views.yml
@@ -1,7 +1,11 @@
 cy:
   layouts:
     application:
-      cookies_intro: Mae GOV.UK yn defnyddio cwcis i wneud y safle'n symlach.
+      cookies_intro_explanation: Mae’r gwasanaeth hwn yn defnyddio cwcis sy’n hanfodol i wneud i’r safle weithio.  Rydym hefyd yn defnyddio cwcis nad ydynt yn rhai hanfodol i’n galluogi i wella eich profiad. 
+      cookies_question: A ydych yn derbyn y cwcis hyn nad ydynt yn rhai hanfodol?
+      accept_cookies: Derbyn cwcis 
+      reject_cookies: Gwrthod cwcis
+      view_more_information: Gweler mwy o wybodaeth
       cookies_find_out_more: Rhagor o wybodaeth am gwcis
       cookies: Cwcis
       ts_and_cs: Telerau ac amodau

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -269,6 +269,22 @@ en:
         <h2 class="heading-large" id="how-cookies-are-used-on-pvb">How cookies are used on PVB</h2>
         <h3 class="heading-medium" id="measuring-website-usage-google-analytics">Measuring website usage (Google Analytics)</h3>
         <p>We use Google Analytics software to collect information about how you use PVB. We do this to help make sure the site is meeting the needs of its users and to help us make improvements.</p>
+        <fieldset>
+          <legend> 
+            Do you agree to the Ministry of Justice and other UK government departments using Google Analytics to help improve the ‘Prison visits’ service?
+          </legend>
+          <div id="id_accept_cookies-wrapper">
+            <div class="multiple-choice">
+              <input id="accept_cookies-yes" type="radio" name="accept_cookies" value="yes">
+              <label for="accept_cookies-yes" id="id_accept_cookies-label">Yes</label>
+            </div>
+            <div class="multiple-choice">
+              <input id="accept_cookies-no" type="radio" name="accept_cookies" value="no">
+              <label for="accept_cookies-no" id="id_accept_cookies-label">No</label>
+            </div>
+          </div>
+          </fieldset>
+          <input id="save_cookie_preference" class="button" type="submit" value="Save changes">
         <p>Google Analytics stores information about:</p>
         <ul class="list list-bullet">
           <li>the pages you visit on PVB – how long you spend on each PVB page</li>
@@ -310,6 +326,11 @@ en:
               <td aria-label="Purpose">Saves a message to let us know that you have seen our cookie message</td>
               <td aria-label="Expires">1 month</td>
             </tr>
+            <tr>
+            <td aria-label="Name">accepted_cookies</td>
+            <td aria-label="Purpose">Stores cookie consent</td>
+            <td aria-label="Expires">1 year</td>
+          </tr>
           </tbody>
         </table>
         <h3 class="heading-medium" id="session">Session</h3>

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -1,13 +1,8 @@
 en:
   layouts:
     application:
-      cookies_intro_html: |
-        <p>
-          This service uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve your experience.
-        </p>
-        <p>
-          Do you accept these non-essential cookies?
-        </p>
+      cookies_intro_explanation: This service uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve your experience.
+      cookies_question: Do you accept these non-essential cookies?
       accept_cookies: Accept cookies
       reject_cookies: Reject cookies
       view_more_information: View more information
@@ -400,25 +395,15 @@ en:
       cancellation_reason:
         one: Cancellation reason
         other: Cancellation reasons
-      cancelled_on:
-        Cancelled on
-      slot_unavailable:
-        The slot you had booked is no longer available.
-      visitor_banned:
-        You have been banned from visiting this prison.
-      booked_in_error:
-        Unfortunately, we made a mistake booking this visit.
-      capacity_issues:
-        We do not have enough space to sit everyone.
-      child_protection_issues:
-        There are restrictions around this prisoner.
-      prisoner_moved:
-        The prisoner has left this prison.
-      prisoner_non_association:
-        There are restrictions around this prisoner.
-      prisoner_released:
-        The prisoner has been released from prison.
-      prisoner_vos:
-        The prisoner has reached the limit of visits during this time period.
+      cancelled_on: Cancelled on
+      slot_unavailable: The slot you had booked is no longer available.
+      visitor_banned: You have been banned from visiting this prison.
+      booked_in_error: Unfortunately, we made a mistake booking this visit.
+      capacity_issues: We do not have enough space to sit everyone.
+      child_protection_issues: There are restrictions around this prisoner.
+      prisoner_moved: The prisoner has left this prison.
+      prisoner_non_association: There are restrictions around this prisoner.
+      prisoner_released: The prisoner has been released from prison.
+      prisoner_vos: The prisoner has reached the limit of visits during this time period.
     withdrawn:
       title: You cancelled this visit request

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -1,7 +1,16 @@
 en:
   layouts:
     application:
-      cookies_intro: GOV.UK uses cookies to make the site simpler.
+      cookies_intro_html: |
+        <p>
+          This service uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve your experience.
+        </p>
+        <p>
+          Do you accept these non-essential cookies?
+        </p>
+      accept_cookies: Accept cookies
+      reject_cookies: Reject cookies
+      view_more_information: View more information
       cookies_find_out_more: Find out more about cookies.
       cookies: Cookies
       ts_and_cs: Terms and conditions

--- a/spec/features/cookie_banner_spec.rb
+++ b/spec/features/cookie_banner_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.feature 'Cookie banner', js: true do
+  include FeaturesHelper
+
+  cookie_banner_text = "This service uses cookies which are essential for the site to work. We also use non-essential cookies to help us improve your experience.\nDo you accept these non-essential cookies?\nAccept cookies Reject cookies View more information"
+
+  scenario 'first navigating to cookies page', vcr: {
+    cassette_name: :private_prison_booking
+  } do
+    visit booking_requests_path(locale: 'en')
+    expect(page).to have_text(cookie_banner_text)
+  end
+
+  scenario 'accpeting cookies', vcr: {
+    cassette_name: :private_prison_booking
+  } do
+    visit booking_requests_path(locale: 'en')
+    click_button 'Accept cookies'
+    expect(page).to_not have_text(cookie_banner_text)
+  end
+
+  scenario 'rejecting cookies', vcr: {
+    cassette_name: :private_prison_booking
+  } do
+    visit booking_requests_path(locale: 'en')
+    click_button 'Reject cookies'
+    expect(page).to_not have_text(cookie_banner_text)
+  end
+
+  scenario 'accepting cookies from cookies page', vcr: {
+    cassette_name: :private_prison_booking
+  } do
+    visit booking_requests_path(locale: 'en')
+    click_on 'View more information'
+    expect(page).to have_text(cookie_banner_text)
+    choose(option: 'yes', visible: false)
+    click_button 'Save changes'
+    expect(page).to_not have_text(cookie_banner_text)
+  end
+
+  scenario 'rejecting cookies from cookies page', vcr: {
+    cassette_name: :private_prison_booking
+  } do
+    visit booking_requests_path(locale: 'en')
+    click_on 'View more information'
+    expect(page).to have_text(cookie_banner_text)
+    choose(option: 'yes', visible: false)
+    click_button 'Save changes'
+    expect(page).to_not have_text(cookie_banner_text)
+  end
+end


### PR DESCRIPTION
This pr is focused on changes required for this service to comply with [gdpr cookie regulations](https://gdpr.eu/cookies/). Previously, the service had a cookie message rendered from the [deprecated template](https://github.com/alphagov/govuk_template/blob/master/source/views/layouts/govuk_template.html.erb) which is in current use. There are some uncertainties regarding what it means to _document and store consent received from users_. Currently, there is a cookie which is set when the user opts in/out. This drives the behaviour around the cookie banner and google analytics tracking.