### PR TITLE
Redirect users away from service

### DIFF
--- a/deploy/production/ingress.yaml
+++ b/deploy/production/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: prison-visits-booking-production
   annotations:
     kubernetes.io/ingress.class: "nginx"
+    nginx.ingress.kubernetes.io/temporal-redirect: https://www.gov.uk/prison-visits
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Due to the Government guidelines because of COVID-19, there will be no prison visits. Currently, PVB users are not able to use the start page on GOV.UK to request visit and there  are comms available for PVB user. For those who have booked mark the visit request page, they could still access the service to request a visit, so they need to be redirected to https://www.gov.uk/prison-visits.