### PR TITLE
peg sprockets to v3 to ease Rails 5.2.4 security upgrade

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'rake'
 gem 'request_store'
 gem 'sassc-rails'
 gem 'sentry-raven', '~> 3.0.0'
+gem 'sprockets', '< 4'
 gem 'string_scrubber'
 gem 'turnout'
 gem 'uglifier', '~> 4.2.0', require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -360,6 +360,7 @@ DEPENDENCIES
   sentry-raven (~> 3.0.0)
   shoulda-matchers
   simplecov
+  sprockets (< 4)
   string_scrubber
   turnout
   uglifier (~> 4.2.0)
@@ -372,4 +373,4 @@ RUBY VERSION
    ruby 2.6.3p62
 
 BUNDLED WITH
-   1.17.2
+   1.17.3


### PR DESCRIPTION
As in prison-visits-2, the Rails 5.2.4 upgrade allows in sprockets 4.x which we don't appear to be ready for. This PR pegs sprockets to the 3.x series, so that the security fix can go in unhindered