### PR TITLE
Bring in govuk-rubocop, disabling most of the noise and fixing up warning messages

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,8 @@
+inherit_gem:
+  rubocop-govuk:
+    - config/default.yml
+    - config/rails.yml
+
 require:
   - rubocop-performance
   - rubocop-rspec
@@ -20,9 +25,6 @@ AllCops:
     - 'lib/tasks/brakeman.rake'
     - 'lib/tasks/elasticsearch.rake'
     - 'spec/dummy/db/**/*'
-
-  DisplayCopNames: true
-
 
 Rails:
   Enabled: true
@@ -78,6 +80,18 @@ Style/SymbolProc:
 Style/TrivialAccessors:
   AllowPredicates: true
 
+Style/TrailingCommaInHashLiteral:
+  Enabled: false
+
+Style/TrailingCommaInArguments:
+  Enabled: false
+
+Style/TrailingCommaInArrayLiteral:
+  Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
 Layout/LineLength:
   Max: 90
   Exclude:
@@ -105,13 +119,13 @@ Style/StringLiterals:
     - 'spec/**/*'
 
 # Prefer sensible naming to comments everywhere.
-Documentation:
+Style/Documentation:
   Description: Document classes and non-namespace modules.
   Enabled: false
 
 # Would enforce do_y if x over if x / do y / end. As with GuardClause above,
 # this enforces code organisation that doesn't necesarily make things clearer.
-IfUnlessModifier:
+Style/IfUnlessModifier:
   Enabled: false
 
 # Don't allow safe assignment in conditions.
@@ -132,7 +146,7 @@ Style/PercentLiteralDelimiters:
     '%W': '[]'
     '%': '{}'
 
-ClassAndModuleChildren:
+Style/ClassAndModuleChildren:
   Enabled: false
 
 # This encourages bad style IMHO

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,7 @@ gem 'uglifier', '~> 4.2.0', require: false
 gem 'uri_template'
 
 group :developmemt do
+  gem 'rubocop-govuk'
   gem 'guard-rspec'
   gem 'guard-rubocop'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,6 +268,10 @@ GEM
       rexml
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.7)
+    rubocop-govuk (3.3.2)
+      rubocop (= 0.80.1)
+      rubocop-rails (~> 2)
+      rubocop-rspec (~> 1.28)
     rubocop-performance (1.6.1)
       rubocop (>= 0.71.0)
     rubocop-rails (2.5.2)
@@ -382,6 +386,7 @@ DEPENDENCIES
   request_store
   rspec-rails (~> 4.0)
   rubocop
+  rubocop-govuk
   rubocop-performance
   rubocop-rails
   rubocop-rspec

--- a/app/models/slots_step.rb
+++ b/app/models/slots_step.rb
@@ -42,7 +42,7 @@ class SlotsStep
 
   def options_available?
     if skip_remaining_slots? || just_reviewed_slot? ||
-       currently_filling_slot_left_blank? || !available_bookable_slots?
+        currently_filling_slot_left_blank? || !available_bookable_slots?
       false
     else
       next_slot_to_fill ? true : false

--- a/app/models/visitors_step.rb
+++ b/app/models/visitors_step.rb
@@ -89,8 +89,6 @@ private
     validate_visitor_collection
   end
 
-  # rubocop:disable Metrics/AbcSize
-  # rubocop:disable Metrics/MethodLength
   def validate_visitor_collection
     # It's invalid if there are no visitors, but there's no need to call the API
     if visitors.none?
@@ -125,8 +123,6 @@ private
                               min: LEAD_VISITOR_MIN_AGE
     end
   end
-  # rubocop:enable Metrics/AbcSize
-  # rubocop:enable Metrics/MethodLength
 
   def lead_visitor
     visitors.first

--- a/app/services/booking_request_creator.rb
+++ b/app/services/booking_request_creator.rb
@@ -1,5 +1,4 @@
 class BookingRequestCreator
-  # rubocop:disable Metrics/MethodLength
   def create!(prisoner_step, visitors_step, slots_step, locale)
     prisoner = prisoner_step.prisoner_attributes
     visitors = visitors_step.visitors.map(&:attributes)
@@ -21,5 +20,4 @@ class BookingRequestCreator
     visit = PrisonVisits::Api.instance.request_visit(params)
     visit
   end
-  # rubocop:enable Metrics/MethodLength
 end

--- a/app/services/prison_visits/api.rb
+++ b/app/services/prison_visits/api.rb
@@ -1,6 +1,5 @@
 module PrisonVisits
   # (in the context of a HTTP API, get_prisons is not bad style)
-  # rubocop:disable Naming/AccessorMethodName
   class Api
     include Singleton
 
@@ -108,5 +107,4 @@ module PrisonVisits
 
     attr_accessor :pool
   end
-  # rubocop:enable Naming/AccessorMethodName
 end

--- a/app/services/prison_visits/client.rb
+++ b/app/services/prison_visits/client.rb
@@ -56,8 +56,6 @@ module PrisonVisits
 
   private
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def request(method, route, params:, idempotent:)
       path = "/api/#{sanitise_route(route)}"
       api_method = "#{method.to_s.upcase} #{path}"
@@ -111,9 +109,6 @@ module PrisonVisits
       # Present non-JSON bodies truncated (e.g. this could be HTML)
       "(invalid-JSON) #{body[0, 80]}"
     end
-
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
 
     # Returns excon options which put params in either the query string or body.
     def params_options(method, params)

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -29,7 +29,7 @@ Rails.application.config.content_security_policy do |config|
     else
       raise '[FATAL] Sentry JS DSN (SENTRY_JS_DSN) is an invalid URI ' \
             '(we were expecting a valid URI with an http or https scheme): ' +
-            sentry_js_dsn
+        sentry_js_dsn
     end
   else
     STDOUT.puts '[WARN] Sentry JS DSN is not set (SENTRY_JS_DSN)'

--- a/config/initializers/turnout.rb
+++ b/config/initializers/turnout.rb
@@ -1,4 +1,3 @@
-# rubocop:disable Layout/LineLength
 Turnout.configure do |config|
   config.app_root = '.'
   config.named_maintenance_file_paths = { default: config.app_root.join('tmp', 'maintenance.yml').to_s }
@@ -9,4 +8,3 @@ Turnout.configure do |config|
   config.default_response_code = 503
   config.default_retry_after = 7200
 end
-# rubocop:enable Layout/LineLength


### PR DESCRIPTION
This repo (prison-visits-public) was using raw rubocop rather than the govuk-rubocop, resulting in warning messages for different rubocop features. This PR just tidies this up, so that the warnings are now removed and the govuk standards are (mostly) enforced