### PR TITLE
Remove temporal-redirect from prod ingress

### DIFF
--- a/deploy/production/ingress.yaml
+++ b/deploy/production/ingress.yaml
@@ -5,7 +5,6 @@ metadata:
   namespace: prison-visits-booking-production
   annotations:
     kubernetes.io/ingress.class: "nginx"
-    nginx.ingress.kubernetes.io/temporal-redirect: https://www.gov.uk/prison-visits
     external-dns.alpha.kubernetes.io/set-identifier: prison-visits-public-prison-visits-booking-production-green
     external-dns.alpha.kubernetes.io/aws-weight: "100"
 spec:


### PR DESCRIPTION
This PR turns off the current redirect routing when a user `visits prisonvisits.service.gov.uk`.

This should only be merged when:

- GDS approve the content changes on gov.uk site, and content is ready to be deployed.
- When prisons have been alerted that the service is back open to the public.