### PR TITLE
VB-1343, added service down message so no page will render

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -53,28 +53,28 @@
 
 <% end %>
 
-<% content_for :content do %>
-  <main id="content">
 
-        <div class="phase-banner phase-banner-beta">
-          <%= t('.feedback_banner_html', url: new_feedback_submission_path) %>
-        </div>
-        <header>
-          <h1 class="heading-xlarge">
-            <%= yield :header %>
-          </h1>
-        </header>
-
-        <% if notice.present? %>
-          <p class="error-summary">
-            <%= notice %>
-          </p>
-        <% end %>
-
-        <%= yield %>
-
+<div class="govuk-width-container">
+  <main class="govuk-main-wrapper govuk-main-wrapper--l" id="main-content" role="main">
+    <div class="govuk-grid-row">
+      <div class="govuk-grid-column-two-thirds">
+        <h1 class="govuk-heading">Sorry, the service is unavailable</h1>
+        <p class="govuk-body">
+          You will not be able to use the service on Wednesday 2 November 2022/
+        </p>
+        <p class="govuk-body">
+          This is due to scheduled maintenance. 
+        </p>
+        <p class="govuk-body">
+          The service will be available again on Thursday 3 November 2022.
+        </p>
+        <p class="govuk-body">
+          <a class="govuk-link" href="https://www.gov.uk/government/collections/prisons-in-england-and-wales">Contact the prison directly</a> if you need to speak to someabout about a visit.
+        </p>
+      </div>
+    </div>
   </main>
-<% end %>
+</div>
 
 <% content_for :footer_support_links do %>
   <ul>


### PR DESCRIPTION
## Description
Removed the 'yield' tag and some surrounding code which renders the content on the page, this will ensure no matter which page the visitors have bookmarks for, they will only be displayed the service down page

## Types of changes
- [x] Temporary service down page

