### PR TITLE
Update views.yml

### DIFF
--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -113,7 +113,7 @@ en:
       prisoner_changed: As you've changed the prisoner details, you need to choose new visit slots.
       info_html: >-
         <p>Choose up to 3 possible dates and times. The prison will confirm one of your choices for the visit.</p>
-        <p>Start with your first choice of date and time.  Available dates are in <span class=bold>bold</span>.</p>
+        <p>Start with your first choice of date and time. The prison’s visit dates are in <span class=bold>bold</span>. These dates may not be available.</p>
       keyboard_directions_html: |
         <ul>
           <li>Press the LEFT and RIGHT arrow keys to navigate the row by week day.</li>


### PR DESCRIPTION
A big proportion of the calls Family Services get are due to visitors saying that their dates are being rejected online even though they’re showing as available. The system states “Available dates are in bold” onthe ‘when do you want to visit?’ page - this is misleading as they may not be available dates if:

* the session if full
* the session is not suitable for the  prisoner
* the session is not suitable for the visitor

We have updated the wording to be more accurate.