### PR TITLE
Welsh privacy policy fix

### DIFF
--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -59,53 +59,9 @@ cy:
       confirmation: Byddwn yn anfon neges e-bost atoch i gadarnhau eich ymweliad,
         felly gwnewch yn siŵr eich bod yn ychwanegu'r cyfeiriad e-bost hwn at eich
         llyfr cyfeiriadau neu restr anfonwyr diogel.
-    terms_and_conditions:
-      title: Telerau ac amodau a pholisi preifatrwydd
+    privacy_policy:
+      title: pholisi preifatrwydd
       body_html: |
-        <p>Drwy ddefnyddio’r gwasanaeth digidol hwn i drefnu i ymweld â rhywun yn y carchar, rydych yn cytuno i’n
-        polisi preifatrwydd ac i’r telerau ac amodau hyn. Darllenwch yn ofalus, os gwelwch yn dda.</p>
-        <h2 class="heading-large" id="telerau-ac-amodau">Telerau ac Amodau</h2>
-        <h3 class="heading-medium" id="cyffredinol">Cyffredinol</h3>
-        <p>Mae’r telerau ac amodau hyn yn effeithio ar eich hawliau a’ch atebolrwydd dan y
-          gyfraith. Maent yn llywodraethu’r defnydd a wnewch, a’r perthynas gyda’r gwasanaeth
-          digidol i wneud cais i ymweld â rhywun yn y carchar. Nid ydynt yn berthnasol wasanaethau eraill a ddarperir gan
-          y Weinyddiaeth Cyfiawnder (Gwasanaeth Carchardai EM), neu i unrhyw adran neu
-        wasanaeth arall sy’n gysylltiedig â’r gwasanaeth hwn.</p>
-        <p>Efallai y byddwn yn diweddaru’r telerau ac amodau hyn o dro i dro. Gall hyn ddigwydd
-          os oes newid yn y gyfraith neu i’r ffordd y mae’r gwasanaeth hwn yn gweithio. Os
-          oes newid, gofynnir i chi gytuno i’r telerau ac amodau
-          newydd y tro nesaf y byddwch yn mewngofnodi, fel y gallwch barhau i ddefnyddio’r
-        gwasanaeth hwn.</p>
-        <p>Os nad ydych yn cytuno i’r telerau ac amodau na’r polisi preifatrwydd a nodir
-        yn y ddogfen hon, ni ddylech ddefnyddio’r gwasanaeth hwn.</p>
-        <h3 class="heading-medium" id="cyfraith-berthnasol">Cyfraith berthnasol</h3>
-        <p>Bydd y defnydd a wnewch o’r gwasanaeth hwn, ac unrhyw anghydfod sy’n codi yn sgil hynny,
-          yn cael ei lywodraethu gan, a’i ddehongli yn unol â chyfreithiau Cymru
-        a Lloegr, gan gynnwys ond nid yn gyfyngedig i’r canlynol:</p>
-        <ul class="list list-bullet">
-          <li>Deddf Camddefnyddio Cyfrifiaduron 1990</li>
-          <li>Deddf Diogelu Data 1998</li>
-          <li>Deddf Galluedd Meddyliol 2005</li>
-        </ul>
-        <h3 class="heading-medium" id="sut-i-ddefnyddior-gwasanaeth-hwn-mewn-ffordd-gyfrifol">Sut i ddefnyddio’r gwasanaeth hwn mewn ffordd gyfrifol</h3>
-        <p>Mae peryglon ynghlwm wrth ddefnyddio cyfrifiadur a rennir, megis mewn caffi rhyngrwyd,
-          i ddefnyddio’r gwasanaeth hwn. Eich cyfrifoldeb chi yw bod yn ymwybodol o’r peryglon hyn
-          ac osgoi defnyddio unrhyw gyfrifiadur allai adael eich gwybodaeth bersonol
-          ar gael i eraill gael mynediad ati. Chi sy’n gyfrifol os byddwch yn dewis
-          i adael cyfrifiadur heb ei ddiogelu pan fyddwch yn y broses o wneud cais
-        i ymweld â rhywun yn y carchar.</p>
-        <p>Rydym yn gwneud ein gorau glas i wirio a phrofi’r gwasanaeth hwn pa bryd bynnag y byddwn yn
-          newid neu’n diweddaru unrhyw beth. Fodd bynnag, rhaid i chi gymryd camau eich hunan i ofalu a sicrhau nad yw’r
-          ffordd yr ydych yn cael mynediad at y gwasanaeth hwn yn eich gwneud yn agored i beryglon
-          firysau, codau cyfrifiaduron maleisus neu ffurfiau eraill o ymyrraeth allai
-        ddifrodi eich system gyfrifiadurol eich hun.</p>
-        <p>Ni ddylech gamddefnyddio ein gwasanaeth drwy gyflwyno firysau, ymwelwyr diwahoddiad,
-          mwydod, bomiau rhesymeg neu ddeunydd arall sy’n faleisus neu’n
-          niweidiol yn dechnolegol. Ni ddylech geisio cael mynediad heb awdurdod
-          i’n gwasanaeth, y system lle cedwir ein gwasanaeth nac unrhyw
-          weinydd, cyfrifiadur neu gronfa data sy’n gysylltiedig â’n gwasanaeth. Ni ddylech
-          ymosod ar ein safle drwy ymosodiad gwrthod gwasanaeth neu ymosodiad atal
-        gwasanaeth.</p>
         <h2 class="heading-large" id="polisi-preifatrwydd">Polisi preifatrwydd</h2>
         <h3 class="heading-medium" id="gwybodaeth-a-ddarperir-gan-y-gwasanaeth-hwn">Gwybodaeth a ddarperir gan y gwasanaeth hwn</h3>
         <p>Rydym yn gweithio’n galed i sicrhau bod yr wybodaeth o fewn y gwasanaeth digidol hwn
@@ -211,6 +167,53 @@ cy:
           Gwasanaethau Digidol, 11.51
           102 Petty France
         Llundain SW1H 9AJ Y Deyrnas Unedig</p>
+    terms_and_conditions:
+      title: Telerau ac amodau
+      body_html: |
+        <p>Drwy ddefnyddio’r gwasanaeth digidol hwn i drefnu i ymweld â rhywun yn y carchar, rydych yn cytuno i’n
+        polisi preifatrwydd ac i’r telerau ac amodau hyn. Darllenwch yn ofalus, os gwelwch yn dda.</p>
+        <h2 class="heading-large" id="telerau-ac-amodau">Telerau ac Amodau</h2>
+        <h3 class="heading-medium" id="cyffredinol">Cyffredinol</h3>
+        <p>Mae’r telerau ac amodau hyn yn effeithio ar eich hawliau a’ch atebolrwydd dan y
+          gyfraith. Maent yn llywodraethu’r defnydd a wnewch, a’r perthynas gyda’r gwasanaeth
+          digidol i wneud cais i ymweld â rhywun yn y carchar. Nid ydynt yn berthnasol wasanaethau eraill a ddarperir gan
+          y Weinyddiaeth Cyfiawnder (Gwasanaeth Carchardai EM), neu i unrhyw adran neu
+        wasanaeth arall sy’n gysylltiedig â’r gwasanaeth hwn.</p>
+        <p>Efallai y byddwn yn diweddaru’r telerau ac amodau hyn o dro i dro. Gall hyn ddigwydd
+          os oes newid yn y gyfraith neu i’r ffordd y mae’r gwasanaeth hwn yn gweithio. Os
+          oes newid, gofynnir i chi gytuno i’r telerau ac amodau
+          newydd y tro nesaf y byddwch yn mewngofnodi, fel y gallwch barhau i ddefnyddio’r
+        gwasanaeth hwn.</p>
+        <p>Os nad ydych yn cytuno i’r telerau ac amodau na’r polisi preifatrwydd a nodir
+        yn y ddogfen hon, ni ddylech ddefnyddio’r gwasanaeth hwn.</p>
+        <h3 class="heading-medium" id="cyfraith-berthnasol">Cyfraith berthnasol</h3>
+        <p>Bydd y defnydd a wnewch o’r gwasanaeth hwn, ac unrhyw anghydfod sy’n codi yn sgil hynny,
+          yn cael ei lywodraethu gan, a’i ddehongli yn unol â chyfreithiau Cymru
+        a Lloegr, gan gynnwys ond nid yn gyfyngedig i’r canlynol:</p>
+        <ul class="list list-bullet">
+          <li>Deddf Camddefnyddio Cyfrifiaduron 1990</li>
+          <li>Deddf Diogelu Data 1998</li>
+          <li>Deddf Galluedd Meddyliol 2005</li>
+        </ul>
+        <h3 class="heading-medium" id="sut-i-ddefnyddior-gwasanaeth-hwn-mewn-ffordd-gyfrifol">Sut i ddefnyddio’r gwasanaeth hwn mewn ffordd gyfrifol</h3>
+        <p>Mae peryglon ynghlwm wrth ddefnyddio cyfrifiadur a rennir, megis mewn caffi rhyngrwyd,
+          i ddefnyddio’r gwasanaeth hwn. Eich cyfrifoldeb chi yw bod yn ymwybodol o’r peryglon hyn
+          ac osgoi defnyddio unrhyw gyfrifiadur allai adael eich gwybodaeth bersonol
+          ar gael i eraill gael mynediad ati. Chi sy’n gyfrifol os byddwch yn dewis
+          i adael cyfrifiadur heb ei ddiogelu pan fyddwch yn y broses o wneud cais
+        i ymweld â rhywun yn y carchar.</p>
+        <p>Rydym yn gwneud ein gorau glas i wirio a phrofi’r gwasanaeth hwn pa bryd bynnag y byddwn yn
+          newid neu’n diweddaru unrhyw beth. Fodd bynnag, rhaid i chi gymryd camau eich hunan i ofalu a sicrhau nad yw’r
+          ffordd yr ydych yn cael mynediad at y gwasanaeth hwn yn eich gwneud yn agored i beryglon
+          firysau, codau cyfrifiaduron maleisus neu ffurfiau eraill o ymyrraeth allai
+        ddifrodi eich system gyfrifiadurol eich hun.</p>
+        <p>Ni ddylech gamddefnyddio ein gwasanaeth drwy gyflwyno firysau, ymwelwyr diwahoddiad,
+          mwydod, bomiau rhesymeg neu ddeunydd arall sy’n faleisus neu’n
+          niweidiol yn dechnolegol. Ni ddylech geisio cael mynediad heb awdurdod
+          i’n gwasanaeth, y system lle cedwir ein gwasanaeth nac unrhyw
+          weinydd, cyfrifiadur neu gronfa data sy’n gysylltiedig â’n gwasanaeth. Ni ddylech
+          ymosod ar ein safle drwy ymosodiad gwrthod gwasanaeth neu ymosodiad atal
+        gwasanaeth.</p>
     cookies:
       title: Cwcis
       body_html: |

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -122,7 +122,7 @@ cy:
         <p>Pawb arall;<br>
           Tîm Datgelu<br>
           Pwynt postio 10.38<br>
-          102 Ffraingc Fach<br>
+          102 Petty France<br>
           Llundain<br>
           SW1H 9AJ</p>
         <h3 class="heading-medium" id="pan-fyddwn-yn-gofyn-i-chi-am-ddata-personol">Pan fyddwn yn gofyn i chi am ddata personol</h3>        
@@ -154,7 +154,7 @@ cy:
         <p>I gael rhagor o wybodaeth am y materion uchod, cysylltwch â:</p>
         <p>Swyddog Diogelu Data'r Weinyddiaeth Gyfiawnder<br>
           Pwynt postio 10.38<br>
-          102 Ffraingc Fach<br>
+          102 Petty France<br>
           Llundain<br>
           SW1H 9AJ</p>
         <p>neu e-bostiwch: data.compliance@justice.gov.uk.</p>
@@ -224,7 +224,7 @@ cy:
         <h3 class="heading-medium" id="cysylltwch-a-ni">Cysylltwch â ni</h3>
         <p>Weinyddiaeth Gyfiawnderh<br>
           Gwasanaethau Digidol<br>
-          11.51, 102 Ffraingc Fach<br>
+          11.51 102 Petty France<br>
           Llundain<br>
           SW1H 9AJ</p>
     cookies:

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -60,7 +60,7 @@ cy:
         felly gwnewch yn siŵr eich bod yn ychwanegu'r cyfeiriad e-bost hwn at eich
         llyfr cyfeiriadau neu restr anfonwyr diogel.
     privacy_policy:
-      title: pholisi preifatrwydd
+      title: Polisi preifatrwydd
       body_html: |
         <h2 class="heading-large" id="polisi-preifatrwydd">Polisi preifatrwydd</h2>
         <h3 class="heading-medium" id="gwybodaeth-a-ddarperir-gan-y-gwasanaeth-hwn">Gwybodaeth a ddarperir gan y gwasanaeth hwn</h3>
@@ -163,10 +163,11 @@ cy:
           neu anwiredd mewn perthynas â mater sylfaenol, nac unrhyw gyfrifoldeb arall
         na ellir ei eithrio neu sy’n gyfyngedig o dan y gyfraith berthnasol.</p>
         <h3 class="heading-medium" id="cysylltwch--ni">Cysylltwch â ni</h3>
-        <p>Y Weinyddiaeth Cyfiawnder
-          Gwasanaethau Digidol, 11.51
-          102 Petty France
-        Llundain SW1H 9AJ Y Deyrnas Unedig</p>
+        <p>Y Weinyddiaeth Cyfiawnder<br>
+          Gwasanaethau Digidol, 11.51<br>
+          102 Petty France<br>
+          Llundain<br>
+          SW1H 9AJ</p>
     terms_and_conditions:
       title: Telerau ac amodau
       body_html: |

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -157,7 +157,7 @@ cy:
           102 Petty France<br>
           Llundain<br>
           SW1H 9AJ</p>
-        <p>neu e-bostiwch: data.compliance@justice.gov.uk.</p>
+        <p>neu e-bostiwch: DPO@justice.gov.uk.</p>
         <p>I gael rhagor o wybodaeth am sut a pham y caiff eich gwybodaeth ei phrosesu, gweler y wybodaeth a ddarparwyd pan wnaethoch chi ddefnyddio ein gwasanaethau neu pan gysylltwyd â ni.</p>
         <h3 class="heading-medium" id="cwynion">Cwynion</h3>
         <p>Pan fyddwn yn gofyn i chi am wybodaeth, byddwn yn cadw at y gyfraith. Os credwch fod eich gwybodaeth wedi cael ei thrin yn anghywir, gallwch gysylltu â’r Comisiynydd Gwybodaeth am gyngor annibynnol ar ddiogelu data yn:</p>

--- a/config/locales/cy/pages.yml
+++ b/config/locales/cy/pages.yml
@@ -62,118 +62,121 @@ cy:
     privacy_policy:
       title: Polisi preifatrwydd
       body_html: |
-        <h2 class="heading-large" id="polisi-preifatrwydd">Polisi preifatrwydd</h2>
-        <h3 class="heading-medium" id="gwybodaeth-a-ddarperir-gan-y-gwasanaeth-hwn">Gwybodaeth a ddarperir gan y gwasanaeth hwn</h3>
-        <p>Rydym yn gweithio’n galed i sicrhau bod yr wybodaeth o fewn y gwasanaeth digidol hwn
-        i wneud cais i ymweld â rhywun yn y carchar yn gywir. Fodd bynnag, ni allwn sicrhau bod yr wybodaeth yn gywir ac yn gyflawn bob amser.</p>
-        <p>Er ein bod yn gwneud pob ymdrech i sicrhau bod y gwasanaeth hwn ar gael bob amser,
-        nid ydym yn gyfrifol os nad yw ar gael am unrhyw gyfnod penodol.</p>
-        <h3 class="heading-medium" id="sut-rydym-yn-defnyddio-eich-gwybodaeth">Sut rydym yn defnyddio eich gwybodaeth</h3>
-        <p>Mae’r Weinyddiaeth Cyfiawnder (Gwasanaeth Carchardai EM) yn defnyddio ac yn cadw
-          data personol ymwelwyr at ddibenion darparu Gwasanaethau Carchardai saff a diogel,
-          gan gynnwys y rhai sy’n berthnasol i reoli ac
-        adsefydlu troseddwyr.</p>
-        <p>Caniateir mynediad i’r sefydliad drwy roi’r wybodaeth
-          y gofynnir amdani’n unig er mwyn sicrhau ein bod yn cynnal amgylchedd saff a diogel
-        i bawb.</p>
-        <p>Mae gennych yr hawl i ofyn am fanylion o ran yr wybodaeth bersonol sydd
-          gennym amdanoch chi; ac o ganlyniad, mae gofyn i ni gywiro unrhyw wybodaeth
-          bersonol sy’n anghywir neu’n hen. Ni fyddwn yn
-          rhannu eich gwybodaeth gyda sefydliadau eraill oni bai ei bod yn ofynnol i ni wneud hynny
-          at ddibenion atal, canfod trosedd, arestio,
-          erlyn, a rheoli troseddwyr; atal terfysgaeth;
-        diogelwch cenedlaethol; neu fod gofyniad cyfreithiol i wneud hynny.</p>
-        <p>Ar wahân i’r wybodaeth sy’n cael ei fewnbynnu gan y sawl sy’n defnyddio’r gwasanaeth hwn, hefyd
-          rydym yn casglu gwybodaeth am y defnydd a wneir o’r safle sy’n ein galluogi i weld sut mae’r
-          gwasanaeth yn cael ei ddefnyddio i’n helpu i’w wella. Nid yw’r
-        wybodaeth hon yn cynnwys unrhyw ddata personol.</p>
-        <p>Mae’n cynnwys:</p>
+        <p>Mae’r polisi preifatrwydd hwn yn esbonio pam mae Gwasanaeth Carchardai a Phrawf EM (HMPPS) yn casglu data personol pan fyddwch yn defnyddio’r gwasanaeth ‘Ymweld â rhywun yn y carchar’.</p>
+        <p>Mae’r polisi hwn hefyd yn egluro:</p>
         <ul class="list list-bullet">
-          <li>cwestiynau, ymholiadau neu adborth y byddwch yn ei adael, gan gynnwys eich cyfeiriad
-          e-bost os byddwch yn anfon neges drwy adborth</li>
-          <li>eich cyfeiriad IP, a manylion y fersiwn o’r porwr gwe a ddefnyddiwyd gennych</li>
-          <li>gwybodaeth ar sut rydych yn defnyddio’r safle, defnyddio cwcis a thechnegau tagio tudalennau
-          i’n helpu i wella’r wefan</li>
+          <li>sut rydym yn storio'r data hwn</li>
+          <li>yr hyn a wnawn ag ef</li>
+          <li>sut y gallwch gael copi o'r data sydd gennym amdanoch</li>
+          <li>sut gallwch chi gwyno os ydych chi’n meddwl ein bod ni wedi gwneud rhywbeth o’i le</li>
+        </ul>
+        <p>Rheolir y gwasanaeth hwn gan HMPPS, un o asiantaethau gweithredol y Weinyddiaeth Gyfiawnder (MOJ). Y Weinyddiaeth Gyfiawnder yw’r rheolydd data ar gyfer y wybodaeth bersonol sydd gennym.</p>       
+        <p>Mae HMPPS yn casglu ac yn prosesu data personol fel y gall ddarparu gwasanaethau carchar yn ddiogel, gan gynnwys y rhai sy’n ymwneud â rheoli ac adsefydlu troseddwyr.</p>
+        <h3 class="heading-medium" id="ynglyn-a-gwybodaeth-bersonol">Ynglŷn â gwybodaeth bersonol</h3>       
+        <p>Gwybodaeth amdanoch chi fel unigolyn yw data personol. Gall fod yn enw, cyfeiriad neu rif ffôn. Gall hefyd gynnwys gwybodaeth am y person yr ydych yn gwneud cais i ymweld ag ef yn y carchar.</p>    
+        <p>Rydym yn gwybod pa mor bwysig yw hi i ddiogelu eich preifatrwydd a chydymffurfio â chyfreithiau diogelu data. Byddwn yn cadw eich data personol yn ddiogel a byddwn ond yn ei ddatgelu pan fo’n gyfreithlon gwneud hynny, neu gyda’ch caniatâd.</p>
+        <h3 class="heading-medium" id="mathau-o-ddata-personol-rydym-yn-ei-brosesu">Mathau o ddata personol rydym yn ei brosesu</h3>
+        <p>Dim ond data personol sy'n berthnasol i'r gwasanaethau yr ydym yn eu darparu i chi y byddwn yn eu prosesu. Mae hyn yn cynnwys:</p>        
+        <ul class="list list-bullet">
+          <li>eich enw, dyddiad geni, cyfeiriad e-bost a rhif ffôn</li>
+          <li>enw, dyddiad geni, rhif carcharor a lleoliad y person rydych am ymweld ag ef</li>
+          <li>enwau a dyddiadau geni unrhyw ymwelwyr ychwanegol</li>
+        </ul>
+        <p>Rydym hefyd yn casglu gwybodaeth defnydd safle sy'n ein galluogi i weld sut mae'r gwasanaeth yn cael ei ddefnyddio er mwyn caniatáu i ni ei wella. Nid yw'r wybodaeth hon yn cynnwys unrhyw ddata personol. Mae'n cynnwys:</p>
+        <ul class="list list-bullet">
+          <li>cwestiynau, ymholiadau neu adborth a adawwch os byddwch yn anfon neges trwy adborth</li>
+          <li>eich cyfeiriad IP, a manylion pa fersiwn o'r porwr gwe a ddefnyddiwyd gennych</li>
+          <li>gwybodaeth am sut rydych chi'n defnyddio'r wefan, gan ddefnyddio cwcis a thechnegau tagio tudalennau i'n helpu i wella'r wefan</li>
         </ul>
         <p>Mae hyn yn ein helpu i:</p>
         <ul class="list list-bullet">
-          <li>wella’r safle drwy fonitro’r ffordd yr ydych yn ei defnyddio</li>
-          <li>ymateb i unrhyw adborth y byddwch yn ei roi i ni, os ydych wedi gofyn i ni wneud hynny</li>
-          <li>darparu gwybodaeth am wasanaethau lleol</li>
+          <li>gwella'r wefan trwy fonitro sut rydych chi'n ei defnyddio</li>
+          <li>ymateb i unrhyw adborth a anfonwch atom, os ydych wedi gofyn i ni wneud hynny</li>
+          <li>rhoi gwybodaeth i chi am wasanaethau lleol os dymunwch</li>
         </ul>
-        <p>Nid ydym yn gallu canfod pwy ydych chi’n bersonol drwy ddefnyddio eich data.</p>
-        <h3 class="heading-medium" id="ym-mhle-mae-eich-data-yn-cael-ei-storio">Ym mhle mae eich data yn cael ei storio</h3>
-        <p>Rydym yn storio eich data ar ein gweinyddwyr diogel yn y DU. Fodd bynnag, efallai y bydd
-          yn cael ei storio y tu allan i Ewrop hefyd, i’n staff neu ein darparwyr weld.
-        Rydych yn cytuno i hyn drwy gyflwyno eich data personol.</p>
-        <p>Hefyd, rydym yn defnyddio cyflenwyr eraill i ddarparu’r gwasanaeth hwn:</p>
+        <p>We can’t personally identify you using your site usage data.</p>        
+        <h3 class="heading-medium" id="pwrpas-prosesu-a-sail-gyfreithlon-y-broses">Pwrpas prosesu a sail gyfreithlon y broses</h3>
+        <p>Rydym yn casglu data personol fel y gallwch wneud cais i ymweld â rhywun yn y carchar. Efallai y byddwn hefyd yn defnyddio’r data i gysylltu â chi i gynnig y cyfle i chi gymryd rhan mewn ymchwil yn y dyfodol i wella ein gwasanaethau.</p>
+        <p>Mae angen y wybodaeth hon ar Garchardai a Sefydliadau Troseddwyr Ifanc er mwyn sicrhau bod ymweliadau'n ddiogel i ymwelwyr, troseddwyr a staff.</p>
+        <h3 class="heading-medium" id="gyda-phwy-y-gellir-rhannur-wybodaeth">Gyda phwy y gellir rhannu'r wybodaeth</h3>       
+        <p>Weithiau mae angen i ni rannu’r wybodaeth bersonol rydym yn ei phrosesu gyda’r unigolyn ei hun a hefyd gyda sefydliadau eraill. Lle bo angen, byddwn yn cydymffurfio â phob agwedd ar y deddfau data. Y sefydliadau rydym yn rhannu eich gwybodaeth bersonol â nhw yw:</p>
         <ul class="list list-bullet">
-          <li><a href="http://sendgrid.com">SendGrid</a> i gyfnewid gwybodaeth â charchardai. Gweler
-            y telerau ac amodau <a href="http://sendgrid.com/tos">terms &amp; conditions</a> sydd ynghlwm wrth
-          y gwasanaeth hwn.</li>
-          <li><a href="http://www.zendesk.com">ZenDesk</a> i ddelio ag unrhyw adborth y byddwch
-            yn ei adael. Gweler y telerau ac amodau <a href="http://www.zendesk.com/company/terms">terms &amp;
-            conditions</a> sydd ynghlwm wrth y gwasanaeth
-          hwn.</li>
+          <li>Ffurflenni'r Weinyddiaeth Gyfiawnder i gasglu adborth. Gweler eu telerau defnyddio.</li>
+          <li>GOV.UK Hysbysu i anfon negeseuon testun ac e-byst atoch. Gweler eu hysbysiad preifatrwydd.</li>
+          <li>ZenDesk i drin unrhyw adborth rydych chi'n ei adael. Gweler y telerau ac amodau sydd ynghlwm wrth y gwasanaeth hwn.</li>
         </ul>
-        <h3 class="heading-medium" id="cadw-eich-data-yn-ddiogel">Cadw eich data yn ddiogel</h3>
-        <p>Yn gyffredinol, nid yw trosglwyddo gwybodaeth dros y we yn gwbl
-          ddiogel, ac ni allwn eich gwarantu y cedwir eich data yn ddiogel.  Fodd bynnag, rydym
-          yn defnyddio SSL er mwyn amgryptio’r holl ddata sy’n cael ei drosglwyddo i mewn a’r data a dderbynnir
-        o’n gweinydd.</p>
-        <p>Rydym yn cymryd diogelwch data o ddifrif, ac rydym yn cymryd pob cam i sicrhau
-        y cedwir eich data yn breifat ac yn ddiogel.</p>
-        <h3 class="heading-medium" id="rydych-yn-cyflwyno-unrhyw-ddata-ar-eich-menter-eich-hun">Rydych yn cyflwyno unrhyw ddata ar eich menter eich hun.</h3>
-        <p>Mae gennym weithdrefnau a nodweddion diogelwch mewn lle i geisio cadw eich
-        data yn ddiogel unwaith y byddwn wedi ei gael.</p>
-        <p>Ni fyddwn yn rhannu eich gwybodaeth gydag unrhyw sefydliadau eraill at ddibenion
-          marchnata, ymchwil marchnad neu ddibenion masnachol ac nid ydym yn anfon
-        eich manylion ymlaen i wefannau eraill.</p>
-        <h3 class="heading-medium" id="datgelu-eich-gwybodaeth">Datgelu eich gwybodaeth</h3>
-        <p>Efallai y byddwn yn anfon eich gwybodaeth bersonol ymlaen os oes gennym ddyletswydd gyfreithiol i wneud hynny.</p>
-        <h3 class="heading-medium" id="sut-rydym-yn-rheoli-sesiynau">Sut rydym yn rheoli sesiynau</h3>
-        <p>Gallwch ddefnyddio’r gwasanaeth hwn i wneud cais i ymweld â rhywun yn carchar.  Bydd eich sesiwn yn fyw
-          am 20 munud, hyd yn oed os byddwch yn cau eich porwr, neu’n llywio i ffwrdd oddi ar y gwasanaeth. Yn ystod y cyfnod hwn, efallai y bydd gwybodaeth bersonol amdanoch chi
-        yn weladwy i unrhyw un sydd â mynediad at eich cyfrifiadur.</p>
-        <p>Bydd eich data yn cael ei gadw ar y cof yn ystod eich sesiwn; bydd hyn yn cael
-        ei glirio 20 munud wedi unrhyw ddiffyg gweithredu.</p>
-        <h3 class="heading-medium" id="deddf-diogelu-data-1998">Deddf Diogelu Data 1998</h3>
-        <p>Mae’r gwasanaeth hwn yn cydymffurfio gyda holl egwyddorion Deddf Diogelu Data 1998.</p>
-        <p>Y Weinyddiaeth Cyfiawnder yw’r ‘rheolydd data’ at ddibenion
-          y Ddeddf. Fodd bynnag, nid yw’r wybodaeth yr ydych yn ei rhoi i mewn i’r gwasanaeth hwn
-          yn cael ei throsglwyddo’n awtomatig i’r Weinyddiaeth Cyfiawnder, ond mae’n cael ei chadw mewn
-        cronfa ddata. Ni fydd unrhyw ddata personol yn ei ddefnyddio wrth brofi’r gwasanaeth hwn.</p>
-        <p>Bydd gan ein darparwr lletya, a staff y Weinyddiaeth Cyfiawnder sy’n gyfrifol am gefnogi’r
-          gwasanaeth hwn, fynediad ar y gweinydd lle mae’r holl wybodaeth bersonol yn cael ei
-          mewnbynnu a lle cedwir y data ar gyfer y gwasanaeth hwn dros dro. Mae’r holl staff
-        sydd â mynediad at y data diogel wedi bod yn destun cliriad diogelwch y Weinyddiaeth Cyfiawnder.</p>
-        <p>Mae gan unrhyw un sy’n credu bod eu data personol yn cael ei gadw o fewn y gwasanaeth hwn
-        yr hawl i gyflwyno cais am fynediad at yr wybodaeth i’r Weinyddiaeth Cyfiawnder, a fydd yn rhoi manylion yr wybodaeth a gedwir ar y gweinydd.</p>
-        <h3 class="heading-medium" id="ymwadiad">Ymwadiad</h3>
-        <p>Nid ydym yn derbyn unrhyw gyfrifoldeb am unrhyw golled neu niwed a achosir o ganlyniad i ddefnyddio’r gwasanaeth hwn, boed yn uniongyrchol, yn anuniongyrchol, pa un ai achosir
-          hyn drwy gamwedd, torri cytundeb neu fel arall. Mae hyn yn cynnwys colli incwm neu
-          refeniw, busnes, elw neu gontractau, arbedion a ragwelir, data,
-          ewyllys da, eiddo diriaethol neu amser a wastraffir yng nghyswllt y
-          gwasanaeth hwn neu unrhyw wefannau cysylltiedig iddo ac unrhyw ddeunyddiau sy’n cael eu postio arno.
-          Ni ddylai’r amod hwn atal gwneud hawliad am golled neu ddifrod i’ch
-          eiddo diriaethol neu unrhyw hawliadau eraill am golled ariannol uniongyrchol nad ydynt
-        wedi’i heithrio gan unrhyw un o’r categorïau a nodir uchod.</p>
-        <p>Nid yw hyn yn effeithio ar ein cyfrifoldeb dros farwolaeth neu anaf personol a achosir
-          o ganlyniad i’n esgeulustod, nac ein cyfrifoldeb dros anwiredd twyllodrus
-          neu anwiredd mewn perthynas â mater sylfaenol, nac unrhyw gyfrifoldeb arall
-        na ellir ei eithrio neu sy’n gyfyngedig o dan y gyfraith berthnasol.</p>
-        <h3 class="heading-medium" id="cysylltwch--ni">Cysylltwch â ni</h3>
-        <p>Y Weinyddiaeth Cyfiawnder<br>
-          Gwasanaethau Digidol, 11.51<br>
-          102 Petty France<br>
+        <h3 class="heading-medium" id="manylion-trosglwyddiadau-i-drydedd-wlad-a-mesurau-diogelu">Manylion trosglwyddiadau i drydedd wlad a mesurau diogelu</h3>      
+        <p>Mae’r holl ddata a gesglir gan y gwasanaeth hwn yn cael ei storio o fewn yr Ardal Economaidd Ewropeaidd (AEE). Fodd bynnag, oherwydd natur fyd-eang y rhyngrwyd, gall y data a anfonir i'r gronfa ddata ac ohoni fynd trwy wledydd y tu allan i'r AEE. Nid yw data’n cael ei storio mewn gwlad nad yw’n rhan o’r AEE. Bydd unrhyw drosglwyddiadau a wneir yn cydymffurfio'n llawn â phob agwedd ar y gyfraith diogelu data.</p>      
+        <h3 class="heading-medium" id="am-ba-mor-hir-rydym-yn-cadw-data">Am ba mor hir rydym yn cadw data</h3>       
+        <p>Cedwir data am saith mlynedd yn unol â pholisi cadw HMPPS.</p>
+        <h3 class="heading-medium" id="mynediad-at-wybodaeth-bersonol">Mynediad at wybodaeth bersonol</h3>   
+        <p>Gallwch ddarganfod a ydym yn cadw unrhyw ddata personol amdanoch trwy wneud ‘cais gwrthrych am wybodaeth’. I wneud cais gwrthrych am wybodaeth cysylltwch â:</p>
+        <p>Troseddwyr a chyn-droseddwyr;<br>
+          Cofrestrfa Branston<br>
+          Adeilad 16, S&T Store<br>
+          Ffordd Burton<br>
+          Branston<br>
+          Burton-on-Trent<br>
+          Swydd Stafford<br>
+          DE14 3EG</p>
+        <p>Pawb arall;<br>
+          Tîm Datgelu<br>
+          Pwynt postio 10.38<br>
+          102 Ffraingc Fach<br>
           Llundain<br>
           SW1H 9AJ</p>
+        <h3 class="heading-medium" id="pan-fyddwn-yn-gofyn-i-chi-am-ddata-personol">Pan fyddwn yn gofyn i chi am ddata personol</h3>        
+        <p>Pryd bynnag y byddwn yn gofyn am ddata personol, rydym yn addo:</p>
+        <ul class="list list-bullet">
+          <li>dim ond gofyn am y wybodaeth sydd ei hangen arnom</li>
+          <li>ei gadw'n ddiogel a gwneud yn siŵr na all neb gael mynediad iddo oni bai bod awdurdod wedi'i awdurdodi</li>
+          <li>gwneud yn siŵr nad ydym yn cadw’r data yn hwy nag sydd angen</li>
+          <li>rhannu'r data gyda sefydliadau eraill at ddibenion cyfreithlon yn unig</li>
+          <li>ystyried unrhyw gais a wnewch i gywiro, rhoi’r gorau i storio neu ddileu eich data personol</li>
+        </ul>       
+        <p>Rydym hefyd yn addo ei gwneud yn hawdd i chi:</p>
+        <ul class="list list-bullet">
+          <li>dweud wrthym ar unrhyw adeg os ydych am i ni roi’r gorau i storio eich data personol</li>
+          <li>gwneud cwyn gyda'r awdurdod goruchwylio</li>
+        </ul>
+        <h3 class="heading-medium" id="sut-rydym-yn-rheoli-sesiynau-ar-lein">Sut rydym yn rheoli sesiynau ar-lein</h3>        
+        <p>Gellir defnyddio'r gwasanaeth hwn i wneud cais am ymweliad carchar. Mae eich sesiwn yn weithredol am 20 munud hyd yn oed os byddwch yn cau eich porwr, neu'n llywio i ffwrdd o'r gwasanaeth hwn. Yn ystod y cyfnod hwn, efallai y bydd gwybodaeth bersonol amdanoch yn weladwy i unrhyw un sydd â mynediad i'ch cyfrifiadur.</p>
+        <p>Cedwir eich data yn y cof yn ystod y sesiwn; caiff hwn ei glirio ar ôl 20 munud o anweithgarwch.</p>
+        <h3 class="heading-medium" id="mwy-o-wybodaethn">Mwy o wybodaeth</h3>    
+        <p>Gallwch gael mwy o fanylion ar:</p>
+        <ul class="list list-bullet">
+          <li>cytundebau sydd gennym gyda sefydliadau eraill ar gyfer rhannu gwybodaeth</li>
+          <li>pryd y gallwn drosglwyddo gwybodaeth bersonol heb ddweud wrthych, er enghraifft, i helpu i atal neu ganfod trosedd neu i gynhyrchu ystadegau dienw</li>
+          <li>cyfarwyddiadau a roddwn i staff ar sut i gasglu, defnyddio neu ddileu eich gwybodaeth bersonol</li>
+          <li>sut rydym yn gwirio bod y wybodaeth sydd gennym yn gywir ac yn gyfredol</li>
+          <li>sut i wneud cwyn</li>
+        </ul>
+        <p>I gael rhagor o wybodaeth am y materion uchod, cysylltwch â:</p>
+        <p>Swyddog Diogelu Data'r Weinyddiaeth Gyfiawnder<br>
+          Pwynt postio 10.38<br>
+          102 Ffraingc Fach<br>
+          Llundain<br>
+          SW1H 9AJ</p>
+        <p>neu e-bostiwch: data.compliance@justice.gov.uk.</p>
+        <p>I gael rhagor o wybodaeth am sut a pham y caiff eich gwybodaeth ei phrosesu, gweler y wybodaeth a ddarparwyd pan wnaethoch chi ddefnyddio ein gwasanaethau neu pan gysylltwyd â ni.</p>
+        <h3 class="heading-medium" id="cwynion">Cwynion</h3>
+        <p>Pan fyddwn yn gofyn i chi am wybodaeth, byddwn yn cadw at y gyfraith. Os credwch fod eich gwybodaeth wedi cael ei thrin yn anghywir, gallwch gysylltu â’r Comisiynydd Gwybodaeth am gyngor annibynnol ar ddiogelu data yn:</p>
+        <p>Swyddfa'r Comisiynydd Gwybodaeth<br>
+          Ty Wycliffe<br>
+          Lôn y Dŵr<br>
+          Wilmslow<br>
+          sir Gaer<br>
+          SK9 5AF<br>
+          Ffôn: 0303 123 1113<br>
+          www.ico.org.uk</p>
+        <h3 class="heading-medium" id="newidiadau-ir-polisi-hwn">Newidiadau i'r polisi hwn</h3>
+        <p>Efallai y byddwn yn newid y polisi preifatrwydd hwn. Yn yr achos hwnnw, bydd y dyddiad ‘diweddaru diwethaf’ ar waelod y dudalen hon hefyd yn newid. Bydd unrhyw newidiadau i'r polisi preifatrwydd hwn yn berthnasol i chi a'ch data ar unwaith.</p>
+        <p>Os bydd y newidiadau hyn yn effeithio ar y ffordd y caiff eich data personol ei brosesu, bydd y Weinyddiaeth Gyfiawnder yn cymryd camau rhesymol i roi gwybod i chi.</p>
+        <p>Wedi ei ddiweddaru ddiwetha' ar 21 Mai 2024.</p>          
     terms_and_conditions:
       title: Telerau ac amodau
       body_html: |
-        <p>Drwy ddefnyddio’r gwasanaeth digidol hwn i drefnu i ymweld â rhywun yn y carchar, rydych yn cytuno i’n
-        polisi preifatrwydd ac i’r telerau ac amodau hyn. Darllenwch yn ofalus, os gwelwch yn dda.</p>
-        <h2 class="heading-large" id="telerau-ac-amodau">Telerau ac Amodau</h2>
+        <p>Trwy ddefnyddio'r gwasanaeth cais digidol ymweliad carchar hwn rydych yn cytuno i'r telerau ac amodau hyn. Darllenwch nhw'n ofalus.</p>
         <h3 class="heading-medium" id="cyffredinol">Cyffredinol</h3>
         <p>Mae’r telerau ac amodau hyn yn effeithio ar eich hawliau a’ch atebolrwydd dan y
           gyfraith. Maent yn llywodraethu’r defnydd a wnewch, a’r perthynas gyda’r gwasanaeth
@@ -215,6 +218,15 @@ cy:
           weinydd, cyfrifiadur neu gronfa data sy’n gysylltiedig â’n gwasanaeth. Ni ddylech
           ymosod ar ein safle drwy ymosodiad gwrthod gwasanaeth neu ymosodiad atal
         gwasanaeth.</p>
+        <h3 class="heading-medium" id="ymwadiadl">Ymwadiad</h3>
+        <p>Nid ydym yn derbyn atebolrwydd am golled neu ddifrod a achosir gan ddefnyddwyr y gwasanaeth hwn, boed yn uniongyrchol, anuniongyrchol neu ganlyniadol, boed hynny oherwydd camwedd, tor-cytundeb neu fel arall. Mae hyn yn cynnwys colli incwm neu refeniw, busnes, elw neu gontractau, arbedion a ragwelir, data, ewyllys da, eiddo diriaethol neu amser a wastraffwyd mewn cysylltiad â’r gwasanaeth hwn neu unrhyw wefannau sy’n gysylltiedig ag ef ac unrhyw ddeunyddiau a bostiwyd arno. Ni fydd yr amod hwn yn atal hawliadau am golled neu ddifrod i'ch eiddo diriaethol nac unrhyw hawliadau eraill am golled ariannol uniongyrchol nad ydynt wedi'u heithrio gan unrhyw un o'r categorïau a nodir uchod.</p>
+        <p>Nid yw hyn yn effeithio ar ein hatebolrwydd am farwolaeth neu anaf personol sy'n deillio o'n hesgeulustod, na'n hatebolrwydd am gamliwio twyllodrus neu gamliwio ynghylch mater sylfaenol, nac unrhyw atebolrwydd arall na ellir ei eithrio na'i gyfyngu dan gyfraith berthnasol.</p>
+        <h3 class="heading-medium" id="cysylltwch-a-ni">Cysylltwch â ni</h3>
+        <p>Weinyddiaeth Gyfiawnderh<br>
+          Gwasanaethau Digidol<br>
+          11.51, 102 Ffraingc Fach<br>
+          Llundain<br>
+          SW1H 9AJ</p>
     cookies:
       title: Cwcis
       body_html: |

--- a/config/locales/cy/views.yml
+++ b/config/locales/cy/views.yml
@@ -9,7 +9,7 @@ cy:
       cookies_find_out_more: Rhagor o wybodaeth am gwcis
       cookies: Cwcis
       ts_and_cs: Telerau ac amodau
-      privacy_policy: Polisi preifatrwydd
+      privacy_policy: Preifatrwydd
       contact_us_html: |
         <a href='%{url}' target='_blank' rel='external'>Adborth</a>
       feedback_banner_html: "<p>\n  <span>Mae'r gwasanaeth hwn yn cael ei wella ac

--- a/config/locales/cy/views.yml
+++ b/config/locales/cy/views.yml
@@ -9,6 +9,7 @@ cy:
       cookies_find_out_more: Rhagor o wybodaeth am gwcis
       cookies: Cwcis
       ts_and_cs: Telerau ac amodau
+      privacy_policy: Polisi preifatrwydd
       contact_us_html: |
         <a href='%{url}' target='_blank' rel='external'>Adborth</a>
       feedback_banner_html: "<p>\n  <span>Mae'r gwasanaeth hwn yn cael ei wella ac

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -249,10 +249,13 @@ en:
           or misrepresentation as to a fundamental matter, nor any other liability
         which cannot be excluded or limited under applicable law.</p>
         <h3  class="heading-medium" id="contact-us">Contact us</h3>
-        <p>Ministry of Justice
-          Digital Services, 11.51
-          102 Petty France
-        London SW1H 9AJ United Kingdom</p>
+        <p>
+          Ministry of Justice</br>
+          Digital Services, 11.51</br>
+          102 Petty France</br>
+          London</br>
+          SW1H 9AJ
+        </p>
     cookies:
       title: Cookies
       body_html: |

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -168,7 +168,7 @@ en:
           London</br>
           SW1H 9AJ
         </p>
-        <p>or email: <a href="data.compliance@justice.gov.uk">data.compliance@justice.gov.uk</a></p>
+        <p>or email: <a href="DPO@justice.gov.uk">DPO@justice.gov.uk</a></p>
         <p>For more information on how and why your information is processed please see the
         information provided when you accessed our services or were contacted by us.<p>
         <h3 class="heading-medium" id="complaints">Complaints</h3>

--- a/config/locales/en/pages.yml
+++ b/config/locales/en/pages.yml
@@ -111,21 +111,21 @@ en:
         <p>You can find out if we hold any personal data about you by making a ‘subject access request’.
         To make a subject access request please contact:</p>
         <p>
-        Offender and ex-offenders;</br>
-        Branston Registry</br>
-        Building 16, S & T Store</br>
-        Burton Road</br>
-        Branston</br>
-        Burton-on-Trent</br>
-        Staffordshire</br>
+        Offender and ex-offenders;<br>
+        Branston Registry<br>
+        Building 16, S & T Store<br>
+        Burton Road<br>
+        Branston<br>
+        Burton-on-Trent<br>
+        Staffordshire<br>
         DE14 3EG
         </p>
         <p>
-        All others;</br>
-        Disclosure Team</br>
-        Post point 10.38</br>
-        102 Petty France</br>
-        London</br>
+        All others;<br>
+        Disclosure Team<br>
+        Post point 10.38<br>
+        102 Petty France<br>
+        London<br>
         SW1H 9AJ
         </p>
         <h3 class="heading-medium" id="when-we-ask-you-for-personal-data">
@@ -162,10 +162,10 @@ en:
         </ul>
         <p>For more information about the above issues, please contact:</p>
         <p>
-          MoJ Data Protection Officer</br>
-          Post point 10.38</br>
-          102 Petty France</br>
-          London</br>
+          MoJ Data Protection Officer<br>
+          Post point 10.38<br>
+          102 Petty France<br>
+          London<br>
           SW1H 9AJ
         </p>
         <p>or email: <a href="DPO@justice.gov.uk">DPO@justice.gov.uk</a></p>
@@ -176,13 +176,13 @@ en:
         handled incorrectly, you can contact the Information Commissioner for independent advice about data
         protection at:</p>
         <p>
-        Information Commissioner's Office</br>
-        Wycliffe House</br>
-        Water Lane</br>
-        Wilmslow</br>
-        Cheshire</br>
-        SK9 5AF</br>
-        Tel: 0303 123 1113</br>
+        Information Commissioner's Office<br>
+        Wycliffe House<br>
+        Water Lane<br>
+        Wilmslow<br>
+        Cheshire<br>
+        SK9 5AF<br>
+        Tel: 0303 123 1113<br>
         <a href="http://www.ico.org.uk">www.ico.org.uk</a>
         </p>
         <h3 class="heading-medium" id="changes">Changes to this policy</h3>
@@ -251,10 +251,10 @@ en:
         which cannot be excluded or limited under applicable law.</p>
         <h3  class="heading-medium" id="contact-us">Contact us</h3>
         <p>
-          Ministry of Justice</br>
-          Digital Services, 11.51</br>
-          102 Petty France</br>
-          London</br>
+          Ministry of Justice<br>
+          Digital Services, 11.51<br>
+          102 Petty France<br>
+          London<br>
           SW1H 9AJ
         </p>
     cookies:

--- a/config/locales/en/views.yml
+++ b/config/locales/en/views.yml
@@ -9,7 +9,7 @@ en:
       cookies_find_out_more: Find out more about cookies.
       cookies: Cookies
       ts_and_cs: Terms and conditions
-      privacy_policy: Privacy policy
+      privacy_policy: Privacy
       contact_us_html: |
         <a href='%{url}' target='_blank' rel='external'>Feedback</a>
       feedback_banner_html: |


### PR DESCRIPTION
During the update to the privacy policy we noticed the Welsh language privacy policy was incorrect:

* the text appeared in the ‘Terms and conditions’ page
* the text was not in sync with the English version
* the welsh translation of the words ‘Privacy policy’ in the footer were not implemented.

This fixes those issues