### PR TITLE
Removes information banner from pages in service

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -58,18 +58,7 @@
     <div class="phase-banner phase-banner-beta">
       <%= t('.feedback_banner_html', url: 'https://visit-someone-in-prison.form.service.justice.gov.uk') %>
     </div>
-    <div class="govuk-notification-banner" role="region" aria-labelledby="govuk-notification-banner-title" data-module="govuk-notification-banner">
-      <div class="govuk-notification-banner__header">
-        <h2 class="govuk-notification-banner__title" id="govuk-notification-banner-title">
-          <%= t('.privacy_policy_header_text') %>
-        </h2>
-      </div>
-      <div class="govuk-notification-banner__content">
-        <p class="govuk-notification-banner__heading">
-          <%= t('.privacy_policy_header_html') %>
-        </p>
-      </div>
-    </div>
+
     <header>
       <h1 class="heading-xlarge">
         <%= yield :header %>


### PR DESCRIPTION
Removes information banner from pages in service related to privacy policy update. Have kept styling in case we need to use it again in the future.