### PR TITLE
Re-link Highdown Nomis connection

### DIFF
--- a/deploy/development/deployment.yaml
+++ b/deploy/development/deployment.yaml
@@ -66,11 +66,17 @@ spec:
         - name: NOMIS_OAUTH_HOST
           value: "https://sign-in-dev.hmpps.service.justice.gov.uk"
         - name: NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED
-          value: "false"
+          value: "true"
         - name: PRISON_API_HOST
           value: "https://prison-api-dev.prison.service.justice.gov.uk"
         - name:  PRISON_VISITS_API
           value: "https://staff.dev.prisonvisits.service.justice.gov.uk/"
+        - name: PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY
+          value: >
+            High Down,
+        - name: STAFF_PRISONS_WITH_SLOT_AVAILABILITY
+          value: >
+            High Down,
         - name: PUBLIC_SERVICE_URL
           value: "https://dev.prisonvisits.service.justice.gov.uk"
         - name: EMAIL_DOMAIN

--- a/deploy/production/deployment.yaml
+++ b/deploy/production/deployment.yaml
@@ -96,9 +96,15 @@ spec:
         - name: NOMIS_OAUTH_HOST
           value: "https://sign-in.hmpps.service.justice.gov.uk"
         - name: NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED
-          value: "false"
+          value: "true"
         - name: PRISON_API_HOST
           value: "https://prison-api.prison.service.justice.gov.uk"
+        - name: PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY
+          value: >
+            High Down,
+        - name: STAFF_PRISONS_WITH_SLOT_AVAILABILITY
+          value: >
+            High Down,
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:

--- a/deploy/staging/deployment.yaml
+++ b/deploy/staging/deployment.yaml
@@ -96,9 +96,15 @@ spec:
         - name: NOMIS_OAUTH_HOST
           value: "https://sign-in-preprod.hmpps.service.justice.gov.uk"
         - name: NOMIS_STAFF_SLOT_AVAILABILITY_ENABLED
-          value: "false"
+          value: "true"
         - name: PRISON_API_HOST
           value: "https://prison-api-preprod.prison.service.justice.gov.uk"
+        - name: PUBLIC_PRISONS_WITH_SLOT_AVAILABILITY
+          value: >
+            High Down,
+        - name: STAFF_PRISONS_WITH_SLOT_AVAILABILITY
+          value: >
+            High Down,
         - name: DATABASE_URL
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
Revert commit [c279ad5](https://github.com/ministryofjustice/prison-visits-public/commit/c279ad5d4b84bf5462f925ae63bb4f9a904b43e2)

Highdown require their NOMIS link to be re-enabled